### PR TITLE
Update interface from standard

### DIFF
--- a/UltiSnips/c.json
+++ b/UltiSnips/c.json
@@ -1,104 +1,14 @@
 {
-"MPI_Start": {
-	"prefix": ["MPI_Start"],
-	"description" : "MPI Start Snippet",
-	"body" : [ "MPI_Start( ${1:MPI_Request* request});"]
+"MPI_Abort": {
+	"prefix": ["MPI_Abort"],
+	"description" : "MPI Abort Snippet",
+	"body" : [ "MPI_Abort( ${1:MPI_Comm comm}, ${2:int errorcode});"]
 },
 
-"MPI_File_write_all_begin": {
-	"prefix": ["MPI_File_write_all_begin"],
-	"description" : "MPI File_write_all_begin Snippet",
-	"body" : [ "MPI_File_write_all_begin( ${1:MPI_File fh}, ${2:void* buf}, ${3:int count}, ${4:MPI_Datatype datatype});"]
-},
-
-"MPI_Win_post": {
-	"prefix": ["MPI_Win_post"],
-	"description" : "MPI Win_post Snippet",
-	"body" : [ "MPI_Win_post( ${1:MPI_Group group}, ${2:int assert}, ${3:MPI_Win win});"]
-},
-
-"MPI_Win_get_errhandler": {
-	"prefix": ["MPI_Win_get_errhandler"],
-	"description" : "MPI Win_get_errhandler Snippet",
-	"body" : [ "MPI_Win_get_errhandler( ${1:MPI_Win win}, ${2:MPI_Errhandler* errhandler});"]
-},
-
-"MPI_File_get_group": {
-	"prefix": ["MPI_File_get_group"],
-	"description" : "MPI File_get_group Snippet",
-	"body" : [ "MPI_File_get_group( ${1:MPI_File fh}, ${2:MPI_Group* group});"]
-},
-
-"MPI_Scan": {
-	"prefix": ["MPI_Scan"],
-	"description" : "MPI Scan Snippet",
-	"body" : [ "MPI_Scan( ${1:void* sendbuf}, ${2:void* recvbuf}, ${3:int count}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:MPI_Comm comm});"]
-},
-
-"MPI_Startall": {
-	"prefix": ["MPI_Startall"],
-	"description" : "MPI Startall Snippet",
-	"body" : [ "MPI_Startall( ${1:int count}, ${2:MPI_Request array_of_requests[]});"]
-},
-
-"MPI_Attr_delete": {
-	"prefix": ["MPI_Attr_delete"],
-	"description" : "MPI Attr_delete Snippet",
-	"body" : [ "MPI_Attr_delete( ${1:MPI_Comm comm}, ${2:int keyval});"]
-},
-
-"MPI_File_iwrite_shared": {
-	"prefix": ["MPI_File_iwrite_shared"],
-	"description" : "MPI File_iwrite_shared Snippet",
-	"body" : [ "MPI_File_iwrite_shared( ${1:MPI_File fh}, ${2:void* buf}, ${3:int count}, ${4:MPI_Datatype datatype}, ${5:MPI_Request* request});"]
-},
-
-"MPI_Comm_get_attr": {
-	"prefix": ["MPI_Comm_get_attr"],
-	"description" : "MPI Comm_get_attr Snippet",
-	"body" : [ "MPI_Comm_get_attr( ${1:MPI_Comm comm}, ${2:int comm_keyval}, ${3:void* attribute_val}, ${4:int* flag});"]
-},
-
-"MPI_File_get_info": {
-	"prefix": ["MPI_File_get_info"],
-	"description" : "MPI File_get_info Snippet",
-	"body" : [ "MPI_File_get_info( ${1:MPI_File fh}, ${2:MPI_Info* info_used});"]
-},
-
-"MPI_Type_delete_attr": {
-	"prefix": ["MPI_Type_delete_attr"],
-	"description" : "MPI Type_delete_attr Snippet",
-	"body" : [ "MPI_Type_delete_attr( ${1:MPI_Datatype type}, ${2:int type_keyval});"]
-},
-
-"MPI_Error_class": {
-	"prefix": ["MPI_Error_class"],
-	"description" : "MPI Error_class Snippet",
-	"body" : [ "MPI_Error_class( ${1:int errorcode}, ${2:int* errorclass});"]
-},
-
-"MPI_Free_mem": {
-	"prefix": ["MPI_Free_mem"],
-	"description" : "MPI Free_mem Snippet",
-	"body" : [ "MPI_Free_mem( ${1:void* base});"]
-},
-
-"MPI_Info_dup": {
-	"prefix": ["MPI_Info_dup"],
-	"description" : "MPI Info_dup Snippet",
-	"body" : [ "MPI_Info_dup( ${1:MPI_Info info}, ${2:MPI_Info* newinfo});"]
-},
-
-"MPI_Type_lb": {
-	"prefix": ["MPI_Type_lb"],
-	"description" : "MPI Type_lb Snippet",
-	"body" : [ "MPI_Type_lb( ${1:MPI_Datatype type}, ${2:MPI_Aint* lb});"]
-},
-
-"MPI_Cart_get": {
-	"prefix": ["MPI_Cart_get"],
-	"description" : "MPI Cart_get Snippet",
-	"body" : [ "MPI_Cart_get( ${1:MPI_Comm comm}, ${2:int maxdims}, ${3:int dims[]}, ${4:int periods[]}, ${5:int coords[]});"]
+"MPI_Accumulate": {
+	"prefix": ["MPI_Accumulate"],
+	"description" : "MPI Accumulate Snippet",
+	"body" : [ "MPI_Accumulate( ${1:const void* origin_addr}, ${2:MPI_Count origin_count}, ${3:MPI_Datatype origin_datatype}, ${4:int target_rank}, ${5:MPI_Aint target_disp}, ${6:MPI_Count target_count}, ${7:MPI_Datatype target_datatype}, ${8:MPI_Op op}, ${9:MPI_Win win});"]
 },
 
 "MPI_Add_error_class": {
@@ -107,1246 +17,52 @@
 	"body" : [ "MPI_Add_error_class( ${1:int* errorclass});"]
 },
 
-"MPI_File_write_shared": {
-	"prefix": ["MPI_File_write_shared"],
-	"description" : "MPI File_write_shared Snippet",
-	"body" : [ "MPI_File_write_shared( ${1:MPI_File fh}, ${2:void* buf}, ${3:int count}, ${4:MPI_Datatype datatype}, ${5:MPI_Status* status});"]
-},
-
-"MPI_Buffer_detach": {
-	"prefix": ["MPI_Buffer_detach"],
-	"description" : "MPI Buffer_detach Snippet",
-	"body" : [ "MPI_Buffer_detach( ${1:void* buffer}, ${2:int* size});"]
-},
-
-"MPI_File_set_size": {
-	"prefix": ["MPI_File_set_size"],
-	"description" : "MPI File_set_size Snippet",
-	"body" : [ "MPI_File_set_size( ${1:MPI_File fh}, ${2:MPI_Offset size});"]
-},
-
-"MPI_Intercomm_create": {
-	"prefix": ["MPI_Intercomm_create"],
-	"description" : "MPI Intercomm_create Snippet",
-	"body" : [ "MPI_Intercomm_create( ${1:MPI_Comm local_comm}, ${2:int local_leader}, ${3:MPI_Comm bridge_comm}, ${4:int remote_leader}, ${5:int tag}, ${6:MPI_Comm* newintercomm});"]
-},
-
-"MPI_File_iread_at": {
-	"prefix": ["MPI_File_iread_at"],
-	"description" : "MPI File_iread_at Snippet",
-	"body" : [ "MPI_File_iread_at( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:void* buf}, ${4:int count}, ${5:MPI_Datatype datatype}, ${6:MPI_Request* request});"]
-},
-
-"MPI_Allreduce": {
-	"prefix": ["MPI_Allreduce"],
-	"description" : "MPI Allreduce Snippet",
-	"body" : [ "MPI_Allreduce( ${1:void* sendbuf}, ${2:void* recvbuf}, ${3:int count}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:MPI_Comm comm});"]
-},
-
-"MPI_Comm_create_keyval": {
-	"prefix": ["MPI_Comm_create_keyval"],
-	"description" : "MPI Comm_create_keyval Snippet",
-	"body" : [ "MPI_Comm_create_keyval( ${1:MPI_Comm_copy_attr_function* comm_copy_attr_fn}, ${2:MPI_Comm_delete_attr_function* comm_delete_attr_fn}, ${3:int* comm_keyval}, ${4:void* extra_state});"]
-},
-
-"MPI_Ibsend": {
-	"prefix": ["MPI_Ibsend"],
-	"description" : "MPI Ibsend Snippet",
-	"body" : [ "MPI_Ibsend( ${1:void* buf}, ${2:int count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
-},
-
-"MPI_File_read_all_end": {
-	"prefix": ["MPI_File_read_all_end"],
-	"description" : "MPI File_read_all_end Snippet",
-	"body" : [ "MPI_File_read_all_end( ${1:MPI_File fh}, ${2:void* buf}, ${3:MPI_Status* status});"]
-},
-
-"MPI_Comm_remote_size": {
-	"prefix": ["MPI_Comm_remote_size"],
-	"description" : "MPI Comm_remote_size Snippet",
-	"body" : [ "MPI_Comm_remote_size( ${1:MPI_Comm comm}, ${2:int* size});"]
-},
-
-"MPI_Type_contiguous": {
-	"prefix": ["MPI_Type_contiguous"],
-	"description" : "MPI Type_contiguous Snippet",
-	"body" : [ "MPI_Type_contiguous( ${1:int count}, ${2:MPI_Datatype oldtype}, ${3:MPI_Datatype* newtype});"]
-},
-
-"MPI_Type_get_name": {
-	"prefix": ["MPI_Type_get_name"],
-	"description" : "MPI Type_get_name Snippet",
-	"body" : [ "MPI_Type_get_name( ${1:MPI_Datatype type}, ${2:char* type_name}, ${3:int* resultlen});"]
-},
-
-"MPI_Reduce": {
-	"prefix": ["MPI_Reduce"],
-	"description" : "MPI Reduce Snippet",
-	"body" : [ "MPI_Reduce( ${1:void* sendbuf}, ${2:void* recvbuf}, ${3:int count}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:int root}, ${7:MPI_Comm comm});"]
-},
-
-"MPI_Type_commit": {
-	"prefix": ["MPI_Type_commit"],
-	"description" : "MPI Type_commit Snippet",
-	"body" : [ "MPI_Type_commit( ${1:MPI_Datatype* type});"]
-},
-
-"MPI_Comm_get_parent": {
-	"prefix": ["MPI_Comm_get_parent"],
-	"description" : "MPI Comm_get_parent Snippet",
-	"body" : [ "MPI_Comm_get_parent( ${1:MPI_Comm* parent});"]
-},
-
-"MPI_Testany": {
-	"prefix": ["MPI_Testany"],
-	"description" : "MPI Testany Snippet",
-	"body" : [ "MPI_Testany( ${1:int count}, ${2:MPI_Request array_of_requests[]}, ${3:int* index}, ${4:int* flag}, ${5:MPI_Status* status});"]
-},
-
-"MPI_Type_extent": {
-	"prefix": ["MPI_Type_extent"],
-	"description" : "MPI Type_extent Snippet",
-	"body" : [ "MPI_Type_extent( ${1:MPI_Datatype type}, ${2:MPI_Aint* extent});"]
-},
-
-"MPI_File_preallocate": {
-	"prefix": ["MPI_File_preallocate"],
-	"description" : "MPI File_preallocate Snippet",
-	"body" : [ "MPI_File_preallocate( ${1:MPI_File fh}, ${2:MPI_Offset size});"]
-},
-
-"MPI_File_get_position": {
-	"prefix": ["MPI_File_get_position"],
-	"description" : "MPI File_get_position Snippet",
-	"body" : [ "MPI_File_get_position( ${1:MPI_File fh}, ${2:MPI_Offset* offset});"]
-},
-
-"MPI_Sendrecv_replace": {
-	"prefix": ["MPI_Sendrecv_replace"],
-	"description" : "MPI Sendrecv_replace Snippet",
-	"body" : [ "MPI_Sendrecv_replace( ${1:void* buf}, ${2:int count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int sendtag}, ${6:int source}, ${7:int recvtag}, ${8:MPI_Comm comm}, ${9:MPI_Status* status});"]
-},
-
-"MPI_Type_get_extent": {
-	"prefix": ["MPI_Type_get_extent"],
-	"description" : "MPI Type_get_extent Snippet",
-	"body" : [ "MPI_Type_get_extent( ${1:MPI_Datatype type}, ${2:MPI_Aint* lb}, ${3:MPI_Aint* extent});"]
-},
-
-"MPI_Keyval_create": {
-	"prefix": ["MPI_Keyval_create"],
-	"description" : "MPI Keyval_create Snippet",
-	"body" : [ "MPI_Keyval_create( ${1:MPI_Copy_function* copy_fn}, ${2:MPI_Delete_function* delete_fn}, ${3:int* keyval}, ${4:void* extra_state});"]
-},
-
-"MPI_Mrecv": {
-	"prefix": ["MPI_Mrecv"],
-	"description" : "MPI Mrecv Snippet",
-	"body" : [ "MPI_Mrecv( ${1:void* buf}, ${2:int count}, ${3:MPI_Datatype datatype}, ${4:MPI_Message* message}, ${5:MPI_Status* status});"]
-},
-
-"MPI_Type_hvector": {
-	"prefix": ["MPI_Type_hvector"],
-	"description" : "MPI Type_hvector Snippet",
-	"body" : [ "MPI_Type_hvector( ${1:int count}, ${2:int blocklength}, ${3:MPI_Aint stride}, ${4:MPI_Datatype oldtype}, ${5:MPI_Datatype* newtype});"]
-},
-
-"MPI_Group_translate_ranks": {
-	"prefix": ["MPI_Group_translate_ranks"],
-	"description" : "MPI Group_translate_ranks Snippet",
-	"body" : [ "MPI_Group_translate_ranks( ${1:MPI_Group group1}, ${2:int n}, ${3:int ranks1[]}, ${4:MPI_Group group2}, ${5:int ranks2[]});"]
-},
-
-"MPI_Testsome": {
-	"prefix": ["MPI_Testsome"],
-	"description" : "MPI Testsome Snippet",
-	"body" : [ "MPI_Testsome( ${1:int incount}, ${2:MPI_Request array_of_requests[]}, ${3:int* outcount}, ${4:int array_of_indices[]}, ${5:MPI_Status array_of_statuses[]});"]
-},
-
-"MPI_Recv_init": {
-	"prefix": ["MPI_Recv_init"],
-	"description" : "MPI Recv_init Snippet",
-	"body" : [ "MPI_Recv_init( ${1:void* buf}, ${2:int count}, ${3:MPI_Datatype datatype}, ${4:int source}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
-},
-
-"MPI_Win_set_name": {
-	"prefix": ["MPI_Win_set_name"],
-	"description" : "MPI Win_set_name Snippet",
-	"body" : [ "MPI_Win_set_name( ${1:MPI_Win win}, ${2:char* win_name});"]
-},
-
-"MPI_Type_dup": {
-	"prefix": ["MPI_Type_dup"],
-	"description" : "MPI Type_dup Snippet",
-	"body" : [ "MPI_Type_dup( ${1:MPI_Datatype type}, ${2:MPI_Datatype* newtype});"]
-},
-
-"MPI_Query_thread": {
-	"prefix": ["MPI_Query_thread"],
-	"description" : "MPI Query_thread Snippet",
-	"body" : [ "MPI_Query_thread( ${1:int* provided});"]
-},
-
-"MPI_Comm_group": {
-	"prefix": ["MPI_Comm_group"],
-	"description" : "MPI Comm_group Snippet",
-	"body" : [ "MPI_Comm_group( ${1:MPI_Comm comm}, ${2:MPI_Group* group});"]
-},
-
 "MPI_Add_error_code": {
 	"prefix": ["MPI_Add_error_code"],
 	"description" : "MPI Add_error_code Snippet",
 	"body" : [ "MPI_Add_error_code( ${1:int errorclass}, ${2:int* errorcode});"]
 },
 
-"MPI_Type_create_resized": {
-	"prefix": ["MPI_Type_create_resized"],
-	"description" : "MPI Type_create_resized Snippet",
-	"body" : [ "MPI_Type_create_resized( ${1:MPI_Datatype oldtype}, ${2:MPI_Aint lb}, ${3:MPI_Aint extent}, ${4:MPI_Datatype* newtype});"]
+"MPI_Add_error_string": {
+	"prefix": ["MPI_Add_error_string"],
+	"description" : "MPI Add_error_string Snippet",
+	"body" : [ "MPI_Add_error_string( ${1:int errorcode}, ${2:const char* string});"]
 },
 
-"MPI_File_seek_shared": {
-	"prefix": ["MPI_File_seek_shared"],
-	"description" : "MPI File_seek_shared Snippet",
-	"body" : [ "MPI_File_seek_shared( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:int whence});"]
+"MPI_Aint_add": {
+	"prefix": ["MPI_Aint_add"],
+	"description" : "MPI Aint_add Snippet",
+	"body" : [ "MPI_Aint_add( ${1:MPI_Aint base}, ${2:MPI_Aint disp});"]
 },
 
-"MPI_Unpublish_name": {
-	"prefix": ["MPI_Unpublish_name"],
-	"description" : "MPI Unpublish_name Snippet",
-	"body" : [ "MPI_Unpublish_name( ${1:char* service_name}, ${2:MPI_Info info}, ${3:char* port_name});"]
-},
-
-"MPI_Get_address": {
-	"prefix": ["MPI_Get_address"],
-	"description" : "MPI Get_address Snippet",
-	"body" : [ "MPI_Get_address( ${1:void* location}, ${2:MPI_Aint* address});"]
-},
-
-"MPI_Is_thread_main": {
-	"prefix": ["MPI_Is_thread_main"],
-	"description" : "MPI Is_thread_main Snippet",
-	"body" : [ "MPI_Is_thread_main( ${1:int* flag});"]
-},
-
-"MPI_Irecv": {
-	"prefix": ["MPI_Irecv"],
-	"description" : "MPI Irecv Snippet",
-	"body" : [ "MPI_Irecv( ${1:void* buf}, ${2:int count}, ${3:MPI_Datatype datatype}, ${4:int source}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
-},
-
-"MPI_Type_create_indexed_block": {
-	"prefix": ["MPI_Type_create_indexed_block"],
-	"description" : "MPI Type_create_indexed_block Snippet",
-	"body" : [ "MPI_Type_create_indexed_block( ${1:int count}, ${2:int blocklength}, ${3:int array_of_displacements[]}, ${4:MPI_Datatype oldtype}, ${5:MPI_Datatype* newtype});"]
-},
-
-"MPI_Initialized": {
-	"prefix": ["MPI_Initialized"],
-	"description" : "MPI Initialized Snippet",
-	"body" : [ "MPI_Initialized( ${1:int* flag});"]
-},
-
-"MPI_File_iwrite": {
-	"prefix": ["MPI_File_iwrite"],
-	"description" : "MPI File_iwrite Snippet",
-	"body" : [ "MPI_File_iwrite( ${1:MPI_File fh}, ${2:void* buf}, ${3:int count}, ${4:MPI_Datatype datatype}, ${5:MPI_Request* request});"]
-},
-
-"MPI_Bsend": {
-	"prefix": ["MPI_Bsend"],
-	"description" : "MPI Bsend Snippet",
-	"body" : [ "MPI_Bsend( ${1:void* buf}, ${2:int count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm});"]
-},
-
-"MPI_Group_excl": {
-	"prefix": ["MPI_Group_excl"],
-	"description" : "MPI Group_excl Snippet",
-	"body" : [ "MPI_Group_excl( ${1:MPI_Group group}, ${2:int n}, ${3:int ranks[]}, ${4:MPI_Group* newgroup});"]
-},
-
-"MPI_Get_count": {
-	"prefix": ["MPI_Get_count"],
-	"description" : "MPI Get_count Snippet",
-	"body" : [ "MPI_Get_count( ${1:MPI_Status* status}, ${2:MPI_Datatype datatype}, ${3:int* count});"]
-},
-
-"MPI_Error_string": {
-	"prefix": ["MPI_Error_string"],
-	"description" : "MPI Error_string Snippet",
-	"body" : [ "MPI_Error_string( ${1:int errorcode}, ${2:char* string}, ${3:int* resultlen});"]
-},
-
-"MPI_Grequest_start": {
-	"prefix": ["MPI_Grequest_start"],
-	"description" : "MPI Grequest_start Snippet",
-	"body" : [ "MPI_Grequest_start( ${1:MPI_Grequest_query_function* query_fn}, ${2:MPI_Grequest_free_function* free_fn}, ${3:MPI_Grequest_cancel_function* cancel_fn}, ${4:void* extra_state}, ${5:MPI_Request* request});"]
-},
-
-"MPI_Cartdim_get": {
-	"prefix": ["MPI_Cartdim_get"],
-	"description" : "MPI Cartdim_get Snippet",
-	"body" : [ "MPI_Cartdim_get( ${1:MPI_Comm comm}, ${2:int* ndims});"]
+"MPI_Aint_diff": {
+	"prefix": ["MPI_Aint_diff"],
+	"description" : "MPI Aint_diff Snippet",
+	"body" : [ "MPI_Aint_diff( ${1:MPI_Aint addr1}, ${2:MPI_Aint addr2});"]
 },
 
 "MPI_Allgather": {
 	"prefix": ["MPI_Allgather"],
 	"description" : "MPI Allgather Snippet",
-	"body" : [ "MPI_Allgather( ${1:void* sendbuf}, ${2:int sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:int recvcount}, ${6:MPI_Datatype recvtype}, ${7:MPI_Comm comm});"]
+	"body" : [ "MPI_Allgather( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:MPI_Count recvcount}, ${6:MPI_Datatype recvtype}, ${7:MPI_Comm comm});"]
 },
 
-"MPI_Cart_coords": {
-	"prefix": ["MPI_Cart_coords"],
-	"description" : "MPI Cart_coords Snippet",
-	"body" : [ "MPI_Cart_coords( ${1:MPI_Comm comm}, ${2:int rank}, ${3:int maxdims}, ${4:int coords[]});"]
-},
-
-"MPI_Scatterv": {
-	"prefix": ["MPI_Scatterv"],
-	"description" : "MPI Scatterv Snippet",
-	"body" : [ "MPI_Scatterv( ${1:void* sendbuf}, ${2:int sendcounts[]}, ${3:int displs[]}, ${4:MPI_Datatype sendtype}, ${5:void* recvbuf}, ${6:int recvcount}, ${7:MPI_Datatype recvtype}, ${8:int root}, ${9:MPI_Comm comm});"]
-},
-
-"MPI_Issend": {
-	"prefix": ["MPI_Issend"],
-	"description" : "MPI Issend Snippet",
-	"body" : [ "MPI_Issend( ${1:void* buf}, ${2:int count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
-},
-
-"MPI_File_sync": {
-	"prefix": ["MPI_File_sync"],
-	"description" : "MPI File_sync Snippet",
-	"body" : [ "MPI_File_sync( ${1:MPI_File fh});"]
-},
-
-"MPI_Rsend": {
-	"prefix": ["MPI_Rsend"],
-	"description" : "MPI Rsend Snippet",
-	"body" : [ "MPI_Rsend( ${1:void* ibuf}, ${2:int count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm});"]
-},
-
-"MPI_File_get_amode": {
-	"prefix": ["MPI_File_get_amode"],
-	"description" : "MPI File_get_amode Snippet",
-	"body" : [ "MPI_File_get_amode( ${1:MPI_File fh}, ${2:int* amode});"]
-},
-
-"MPI_Abort": {
-	"prefix": ["MPI_Abort"],
-	"description" : "MPI Abort Snippet",
-	"body" : [ "MPI_Abort( ${1:MPI_Comm comm}, ${2:int errorcode});"]
-},
-
-"MPI_Grequest_complete": {
-	"prefix": ["MPI_Grequest_complete"],
-	"description" : "MPI Grequest_complete Snippet",
-	"body" : [ "MPI_Grequest_complete( ${1:MPI_Request request});"]
-},
-
-"MPI_Pack": {
-	"prefix": ["MPI_Pack"],
-	"description" : "MPI Pack Snippet",
-	"body" : [ "MPI_Pack( ${1:void* inbuf}, ${2:int incount}, ${3:MPI_Datatype datatype}, ${4:void* outbuf}, ${5:int outsize}, ${6:int* position}, ${7:MPI_Comm comm});"]
-},
-
-"MPI_Win_set_attr": {
-	"prefix": ["MPI_Win_set_attr"],
-	"description" : "MPI Win_set_attr Snippet",
-	"body" : [ "MPI_Win_set_attr( ${1:MPI_Win win}, ${2:int win_keyval}, ${3:void* attribute_val});"]
-},
-
-"MPI_Info_create": {
-	"prefix": ["MPI_Info_create"],
-	"description" : "MPI Info_create Snippet",
-	"body" : [ "MPI_Info_create( ${1:MPI_Info* info});"]
-},
-
-"MPI_File_open": {
-	"prefix": ["MPI_File_open"],
-	"description" : "MPI File_open Snippet",
-	"body" : [ "MPI_File_open( ${1:MPI_Comm comm}, ${2:char* filename}, ${3:int amode}, ${4:MPI_Info info}, ${5:MPI_File* fh});"]
-},
-
-"MPI_Gatherv": {
-	"prefix": ["MPI_Gatherv"],
-	"description" : "MPI Gatherv Snippet",
-	"body" : [ "MPI_Gatherv( ${1:void* sendbuf}, ${2:int sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:int recvcounts[]}, ${6:int displs[]}, ${7:MPI_Datatype recvtype}, ${8:int root}, ${9:MPI_Comm comm});"]
-},
-
-"MPI_Type_get_attr": {
-	"prefix": ["MPI_Type_get_attr"],
-	"description" : "MPI Type_get_attr Snippet",
-	"body" : [ "MPI_Type_get_attr( ${1:MPI_Datatype type}, ${2:int type_keyval}, ${3:void* attribute_val}, ${4:int* flag});"]
-},
-
-"MPI_Comm_set_name": {
-	"prefix": ["MPI_Comm_set_name"],
-	"description" : "MPI Comm_set_name Snippet",
-	"body" : [ "MPI_Comm_set_name( ${1:MPI_Comm comm}, ${2:char* comm_name});"]
-},
-
-"MPI_Comm_disconnect": {
-	"prefix": ["MPI_Comm_disconnect"],
-	"description" : "MPI Comm_disconnect Snippet",
-	"body" : [ "MPI_Comm_disconnect( ${1:MPI_Comm* comm});"]
-},
-
-"MPI_Comm_remote_group": {
-	"prefix": ["MPI_Comm_remote_group"],
-	"description" : "MPI Comm_remote_group Snippet",
-	"body" : [ "MPI_Comm_remote_group( ${1:MPI_Comm comm}, ${2:MPI_Group* group});"]
-},
-
-"MPI_Cart_shift": {
-	"prefix": ["MPI_Cart_shift"],
-	"description" : "MPI Cart_shift Snippet",
-	"body" : [ "MPI_Cart_shift( ${1:MPI_Comm comm}, ${2:int direction}, ${3:int disp}, ${4:int* rank_source}, ${5:int* rank_dest});"]
-},
-
-"MPI_Init_thread": {
-	"prefix": ["MPI_Init_thread"],
-	"description" : "MPI Init_thread Snippet",
-	"body" : [ "MPI_Init_thread( ${1:int* argc}, ${2:char*** argv}, ${3:int req}, ${4:int* provided});"]
-},
-
-"MPI_Comm_size": {
-	"prefix": ["MPI_Comm_size"],
-	"description" : "MPI Comm_size Snippet",
-	"body" : [ "MPI_Comm_size( ${1:MPI_Comm comm}, ${2:int* size});"]
-},
-
-"MPI_Type_get_envelope": {
-	"prefix": ["MPI_Type_get_envelope"],
-	"description" : "MPI Type_get_envelope Snippet",
-	"body" : [ "MPI_Type_get_envelope( ${1:MPI_Datatype type}, ${2:int* num_integers}, ${3:int* num_addresses}, ${4:int* num_datatypes}, ${5:int* combiner});"]
-},
-
-"MPI_File_iread_shared": {
-	"prefix": ["MPI_File_iread_shared"],
-	"description" : "MPI File_iread_shared Snippet",
-	"body" : [ "MPI_File_iread_shared( ${1:MPI_File fh}, ${2:void* buf}, ${3:int count}, ${4:MPI_Datatype datatype}, ${5:MPI_Request* request});"]
-},
-
-"MPI_File_set_errhandler": {
-	"prefix": ["MPI_File_set_errhandler"],
-	"description" : "MPI File_set_errhandler Snippet",
-	"body" : [ "MPI_File_set_errhandler( ${1:MPI_File file}, ${2:MPI_Errhandler errhandler});"]
-},
-
-"MPI_Register_datarep": {
-	"prefix": ["MPI_Register_datarep"],
-	"description" : "MPI Register_datarep Snippet",
-	"body" : [ "MPI_Register_datarep( ${1:char* datarep}, ${2:MPI_Datarep_conversion_function* read_conversion_fn}, ${3:MPI_Datarep_conversion_function* write_conversion_fn}, ${4:MPI_Datarep_extent_function* dtype_file_extent_fn}, ${5:void* extra_state});"]
-},
-
-"MPI_File_read_ordered": {
-	"prefix": ["MPI_File_read_ordered"],
-	"description" : "MPI File_read_ordered Snippet",
-	"body" : [ "MPI_File_read_ordered( ${1:MPI_File fh}, ${2:void* buf}, ${3:int count}, ${4:MPI_Datatype datatype}, ${5:MPI_Status* status});"]
-},
-
-"MPI_Init": {
-	"prefix": ["MPI_Init"],
-	"description" : "MPI Init Snippet",
-	"body" : [ "MPI_Init( ${1:int* argc}, ${2:char *** argv});"]
-},
-
-"MPI_Waitsome": {
-	"prefix": ["MPI_Waitsome"],
-	"description" : "MPI Waitsome Snippet",
-	"body" : [ "MPI_Waitsome( ${1:int incount}, ${2:MPI_Request array_of_requests[]}, ${3:int* outcount}, ${4:int array_of_indices[]}, ${5:MPI_Status array_of_statuses[]});"]
-},
-
-"MPI_Group_difference": {
-	"prefix": ["MPI_Group_difference"],
-	"description" : "MPI Group_difference Snippet",
-	"body" : [ "MPI_Group_difference( ${1:MPI_Group group1}, ${2:MPI_Group group2}, ${3:MPI_Group* newgroup});"]
-},
-
-"MPI_Attr_get": {
-	"prefix": ["MPI_Attr_get"],
-	"description" : "MPI Attr_get Snippet",
-	"body" : [ "MPI_Attr_get( ${1:MPI_Comm comm}, ${2:int keyval}, ${3:void* attribute_val}, ${4:int* flag});"]
-},
-
-"MPI_Reduce_scatter": {
-	"prefix": ["MPI_Reduce_scatter"],
-	"description" : "MPI Reduce_scatter Snippet",
-	"body" : [ "MPI_Reduce_scatter( ${1:void* sendbuf}, ${2:void* recvbuf}, ${3:int recvcounts[]}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:MPI_Comm comm});"]
-},
-
-"MPI_Group_incl": {
-	"prefix": ["MPI_Group_incl"],
-	"description" : "MPI Group_incl Snippet",
-	"body" : [ "MPI_Group_incl( ${1:MPI_Group group}, ${2:int n}, ${3:int ranks[]}, ${4:MPI_Group* newgroup});"]
-},
-
-"MPI_Imrecv": {
-	"prefix": ["MPI_Imrecv"],
-	"description" : "MPI Imrecv Snippet",
-	"body" : [ "MPI_Imrecv( ${1:void* buf}, ${2:int count}, ${3:MPI_Datatype datatype}, ${4:MPI_Message* message}, ${5:MPI_Request* status});"]
-},
-
-"MPI_Wait": {
-	"prefix": ["MPI_Wait"],
-	"description" : "MPI Wait Snippet",
-	"body" : [ "MPI_Wait( ${1:MPI_Request* request}, ${2:MPI_Status* status});"]
-},
-
-"MPI_Testall": {
-	"prefix": ["MPI_Testall"],
-	"description" : "MPI Testall Snippet",
-	"body" : [ "MPI_Testall( ${1:int count}, ${2:MPI_Request array_of_requests[]}, ${3:int* flag}, ${4:MPI_Status array_of_statuses[]});"]
-},
-
-"MPI_File_set_info": {
-	"prefix": ["MPI_File_set_info"],
-	"description" : "MPI File_set_info Snippet",
-	"body" : [ "MPI_File_set_info( ${1:MPI_File fh}, ${2:MPI_Info info});"]
-},
-
-"MPI_Irsend": {
-	"prefix": ["MPI_Irsend"],
-	"description" : "MPI Irsend Snippet",
-	"body" : [ "MPI_Irsend( ${1:void* buf}, ${2:int count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
-},
-
-"MPI_Get_version": {
-	"prefix": ["MPI_Get_version"],
-	"description" : "MPI Get_version Snippet",
-	"body" : [ "MPI_Get_version( ${1:int* version}, ${2:int* subversion});"]
-},
-
-"MPI_Comm_create_errhandler": {
-	"prefix": ["MPI_Comm_create_errhandler"],
-	"description" : "MPI Comm_create_errhandler Snippet",
-	"body" : [ "MPI_Comm_create_errhandler( ${1:MPI_Comm_errhandler_function* function}, ${2:MPI_Errhandler* errhandler});"]
-},
-
-"MPI_File_write_all": {
-	"prefix": ["MPI_File_write_all"],
-	"description" : "MPI File_write_all Snippet",
-	"body" : [ "MPI_File_write_all( ${1:MPI_File fh}, ${2:void* buf}, ${3:int count}, ${4:MPI_Datatype datatype}, ${5:MPI_Status* status});"]
-},
-
-"MPI_Comm_connect": {
-	"prefix": ["MPI_Comm_connect"],
-	"description" : "MPI Comm_connect Snippet",
-	"body" : [ "MPI_Comm_connect( ${1:char* port_name}, ${2:MPI_Info info}, ${3:int root}, ${4:MPI_Comm comm}, ${5:MPI_Comm* newcomm});"]
-},
-
-"MPI_Group_compare": {
-	"prefix": ["MPI_Group_compare"],
-	"description" : "MPI Group_compare Snippet",
-	"body" : [ "MPI_Group_compare( ${1:MPI_Group group1}, ${2:MPI_Group group2}, ${3:int* result});"]
-},
-
-"MPI_Address": {
-	"prefix": ["MPI_Address"],
-	"description" : "MPI Address Snippet",
-	"body" : [ "MPI_Address( ${1:void* location}, ${2:MPI_Aint* address});"]
-},
-
-"MPI_Comm_compare": {
-	"prefix": ["MPI_Comm_compare"],
-	"description" : "MPI Comm_compare Snippet",
-	"body" : [ "MPI_Comm_compare( ${1:MPI_Comm comm1}, ${2:MPI_Comm comm2}, ${3:int* result});"]
-},
-
-"MPI_Win_unlock": {
-	"prefix": ["MPI_Win_unlock"],
-	"description" : "MPI Win_unlock Snippet",
-	"body" : [ "MPI_Win_unlock( ${1:int rank}, ${2:MPI_Win win});"]
-},
-
-"MPI_Pack_external": {
-	"prefix": ["MPI_Pack_external"],
-	"description" : "MPI Pack_external Snippet",
-	"body" : [ "MPI_Pack_external( ${1:char* datarep}, ${2:void* inbuf}, ${3:int incount}, ${4:MPI_Datatype datatype}, ${5:void* outbuf}, ${6:MPI_Aint outsize}, ${7:MPI_Aint* position});"]
-},
-
-"MPI_Request_free": {
-	"prefix": ["MPI_Request_free"],
-	"description" : "MPI Request_free Snippet",
-	"body" : [ "MPI_Request_free( ${1:MPI_Request* request});"]
-},
-
-"MPI_Topo_test": {
-	"prefix": ["MPI_Topo_test"],
-	"description" : "MPI Topo_test Snippet",
-	"body" : [ "MPI_Topo_test( ${1:MPI_Comm comm}, ${2:int* status});"]
-},
-
-"MPI_File_read": {
-	"prefix": ["MPI_File_read"],
-	"description" : "MPI File_read Snippet",
-	"body" : [ "MPI_File_read( ${1:MPI_File fh}, ${2:void* buf}, ${3:int count}, ${4:MPI_Datatype datatype}, ${5:MPI_Status* status});"]
-},
-
-"MPI_Buffer_attach": {
-	"prefix": ["MPI_Buffer_attach"],
-	"description" : "MPI Buffer_attach Snippet",
-	"body" : [ "MPI_Buffer_attach( ${1:void* buffer}, ${2:int size});"]
-},
-
-"MPI_Win_call_errhandler": {
-	"prefix": ["MPI_Win_call_errhandler"],
-	"description" : "MPI Win_call_errhandler Snippet",
-	"body" : [ "MPI_Win_call_errhandler( ${1:MPI_Win win}, ${2:int errorcode});"]
-},
-
-"MPI_Win_get_group": {
-	"prefix": ["MPI_Win_get_group"],
-	"description" : "MPI Win_get_group Snippet",
-	"body" : [ "MPI_Win_get_group( ${1:MPI_Win win}, ${2:MPI_Group* group});"]
-},
-
-"MPI_Errhandler_create": {
-	"prefix": ["MPI_Errhandler_create"],
-	"description" : "MPI Errhandler_create Snippet",
-	"body" : [ "MPI_Errhandler_create( ${1:MPI_Handler_function* function}, ${2:MPI_Errhandler* errhandler});"]
-},
-
-"MPI_Cart_create": {
-	"prefix": ["MPI_Cart_create"],
-	"description" : "MPI Cart_create Snippet",
-	"body" : [ "MPI_Cart_create( ${1:MPI_Comm old_comm}, ${2:int ndims}, ${3:int dims[]}, ${4:int periods[]}, ${5:int reorder}, ${6:MPI_Comm* comm_cart});"]
-},
-
-"MPI_Status_set_cancelled": {
-	"prefix": ["MPI_Status_set_cancelled"],
-	"description" : "MPI Status_set_cancelled Snippet",
-	"body" : [ "MPI_Status_set_cancelled( ${1:MPI_Status* status}, ${2:int flag});"]
-},
-
-"MPI_Win_get_attr": {
-	"prefix": ["MPI_Win_get_attr"],
-	"description" : "MPI Win_get_attr Snippet",
-	"body" : [ "MPI_Win_get_attr( ${1:MPI_Win win}, ${2:int win_keyval}, ${3:void* attribute_val}, ${4:int* flag});"]
-},
-
-"MPI_Type_struct": {
-	"prefix": ["MPI_Type_struct"],
-	"description" : "MPI Type_struct Snippet",
-	"body" : [ "MPI_Type_struct( ${1:int count}, ${2:int array_of_blocklengths[]}, ${3:MPI_Aint array_of_displacements[]}, ${4:MPI_Datatype array_of_types[]}, ${5:MPI_Datatype* newtype});"]
-},
-
-"MPI_Graph_neighbors_count": {
-	"prefix": ["MPI_Graph_neighbors_count"],
-	"description" : "MPI Graph_neighbors_count Snippet",
-	"body" : [ "MPI_Graph_neighbors_count( ${1:MPI_Comm comm}, ${2:int rank}, ${3:int* nneighbors});"]
-},
-
-"MPI_File_get_view": {
-	"prefix": ["MPI_File_get_view"],
-	"description" : "MPI File_get_view Snippet",
-	"body" : [ "MPI_File_get_view( ${1:MPI_File fh}, ${2:MPI_Offset* disp}, ${3:MPI_Datatype* etype}, ${4:MPI_Datatype* filetype}, ${5:char* datarep});"]
+"MPI_Allgather_init": {
+	"prefix": ["MPI_Allgather_init"],
+	"description" : "MPI Allgather_init Snippet",
+	"body" : [ "MPI_Allgather_init( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:MPI_Count recvcount}, ${6:MPI_Datatype recvtype}, ${7:MPI_Comm comm}, ${8:MPI_Info info}, ${9:MPI_Request* request});"]
 },
 
 "MPI_Allgatherv": {
 	"prefix": ["MPI_Allgatherv"],
 	"description" : "MPI Allgatherv Snippet",
-	"body" : [ "MPI_Allgatherv( ${1:void* sendbuf}, ${2:int sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:int recvcounts[]}, ${6:int displs[]}, ${7:MPI_Datatype recvtype}, ${8:MPI_Comm comm});"]
+	"body" : [ "MPI_Allgatherv( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:const MPI_Count recvcounts[]}, ${6:const MPI_Aint displs[]}, ${7:MPI_Datatype recvtype}, ${8:MPI_Comm comm});"]
 },
 
-"MPI_Sendrecv": {
-	"prefix": ["MPI_Sendrecv"],
-	"description" : "MPI Sendrecv Snippet",
-	"body" : [ "MPI_Sendrecv( ${1:void* sendbuf}, ${2:int sendcount}, ${3:MPI_Datatype sendtype}, ${4:int dest}, ${5:int sendtag}, ${6:void* recvbuf}, ${7:int recvcount}, ${8:MPI_Datatype recvtype}, ${9:int source}, ${10:int recvtag}, ${11:MPI_Comm comm}, ${12:MPI_Status* status});"]
-},
-
-"MPI_File_get_position_shared": {
-	"prefix": ["MPI_File_get_position_shared"],
-	"description" : "MPI File_get_position_shared Snippet",
-	"body" : [ "MPI_File_get_position_shared( ${1:MPI_File fh}, ${2:MPI_Offset* offset});"]
-},
-
-"MPI_Graph_neighbors": {
-	"prefix": ["MPI_Graph_neighbors"],
-	"description" : "MPI Graph_neighbors Snippet",
-	"body" : [ "MPI_Graph_neighbors( ${1:MPI_Comm comm}, ${2:int rank}, ${3:int maxneighbors}, ${4:int neighbors[]});"]
-},
-
-"MPI_Dims_create": {
-	"prefix": ["MPI_Dims_create"],
-	"description" : "MPI Dims_create Snippet",
-	"body" : [ "MPI_Dims_create( ${1:int nnodes}, ${2:int ndims}, ${3:int dims[]});"]
-},
-
-"MPI_File_iread": {
-	"prefix": ["MPI_File_iread"],
-	"description" : "MPI File_iread Snippet",
-	"body" : [ "MPI_File_iread( ${1:MPI_File fh}, ${2:void* buf}, ${3:int count}, ${4:MPI_Datatype datatype}, ${5:MPI_Request* request});"]
-},
-
-"MPI_Scatter": {
-	"prefix": ["MPI_Scatter"],
-	"description" : "MPI Scatter Snippet",
-	"body" : [ "MPI_Scatter( ${1:void* sendbuf}, ${2:int sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:int recvcount}, ${6:MPI_Datatype recvtype}, ${7:int root}, ${8:MPI_Comm comm});"]
-},
-
-"MPI_File_get_byte_offset": {
-	"prefix": ["MPI_File_get_byte_offset"],
-	"description" : "MPI File_get_byte_offset Snippet",
-	"body" : [ "MPI_File_get_byte_offset( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:MPI_Offset* disp});"]
-},
-
-"MPI_Comm_free_keyval": {
-	"prefix": ["MPI_Comm_free_keyval"],
-	"description" : "MPI Comm_free_keyval Snippet",
-	"body" : [ "MPI_Comm_free_keyval( ${1:int* comm_keyval});"]
-},
-
-"MPI_Op_create": {
-	"prefix": ["MPI_Op_create"],
-	"description" : "MPI Op_create Snippet",
-	"body" : [ "MPI_Op_create( ${1:MPI_User_function* function}, ${2:int commute}, ${3:MPI_Op* op});"]
-},
-
-"MPI_File_seek": {
-	"prefix": ["MPI_File_seek"],
-	"description" : "MPI File_seek Snippet",
-	"body" : [ "MPI_File_seek( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:int whence});"]
-},
-
-"MPI_Add_error_string": {
-	"prefix": ["MPI_Add_error_string"],
-	"description" : "MPI Add_error_string Snippet",
-	"body" : [ "MPI_Add_error_string( ${1:int errorcode}, ${2:char* string});"]
-},
-
-"MPI_Mprobe": {
-	"prefix": ["MPI_Mprobe"],
-	"description" : "MPI Mprobe Snippet",
-	"body" : [ "MPI_Mprobe( ${1:int source}, ${2:int tag}, ${3:MPI_Comm comm}, ${4:MPI_Message* message}, ${5:MPI_Status* status});"]
-},
-
-"MPI_Ssend_init": {
-	"prefix": ["MPI_Ssend_init"],
-	"description" : "MPI Ssend_init Snippet",
-	"body" : [ "MPI_Ssend_init( ${1:void* buf}, ${2:int count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
-},
-
-"MPI_Rsend_init": {
-	"prefix": ["MPI_Rsend_init"],
-	"description" : "MPI Rsend_init Snippet",
-	"body" : [ "MPI_Rsend_init( ${1:void* buf}, ${2:int count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
-},
-
-"MPI_Info_free": {
-	"prefix": ["MPI_Info_free"],
-	"description" : "MPI Info_free Snippet",
-	"body" : [ "MPI_Info_free( ${1:MPI_Info* info});"]
-},
-
-"MPI_Publish_name": {
-	"prefix": ["MPI_Publish_name"],
-	"description" : "MPI Publish_name Snippet",
-	"body" : [ "MPI_Publish_name( ${1:char* service_name}, ${2:MPI_Info info}, ${3:char* port_name});"]
-},
-
-"MPI_Bcast": {
-	"prefix": ["MPI_Bcast"],
-	"description" : "MPI Bcast Snippet",
-	"body" : [ "MPI_Bcast( ${1:void* buffer}, ${2:int count}, ${3:MPI_Datatype datatype}, ${4:int root}, ${5:MPI_Comm comm});"]
-},
-
-"MPI_Get_processor_name": {
-	"prefix": ["MPI_Get_processor_name"],
-	"description" : "MPI Get_processor_name Snippet",
-	"body" : [ "MPI_Get_processor_name( ${1:char* name}, ${2:int* resultlen});"]
-},
-
-"MPI_Info_set": {
-	"prefix": ["MPI_Info_set"],
-	"description" : "MPI Info_set Snippet",
-	"body" : [ "MPI_Info_set( ${1:MPI_Info info}, ${2:char* key}, ${3:char* value});"]
-},
-
-"MPI_File_write_ordered_end": {
-	"prefix": ["MPI_File_write_ordered_end"],
-	"description" : "MPI File_write_ordered_end Snippet",
-	"body" : [ "MPI_File_write_ordered_end( ${1:MPI_File fh}, ${2:void* buf}, ${3:MPI_Status* status});"]
-},
-
-"MPI_Graph_create": {
-	"prefix": ["MPI_Graph_create"],
-	"description" : "MPI Graph_create Snippet",
-	"body" : [ "MPI_Graph_create( ${1:MPI_Comm comm}, ${2:int nnodes}, ${3:int index[]}, ${4:int edges[]}, ${5:int reorder}, ${6:MPI_Comm* comm_graph});"]
-},
-
-"MPI_Comm_free": {
-	"prefix": ["MPI_Comm_free"],
-	"description" : "MPI Comm_free Snippet",
-	"body" : [ "MPI_Comm_free( ${1:MPI_Comm* comm});"]
-},
-
-"MPI_File_write_at_all": {
-	"prefix": ["MPI_File_write_at_all"],
-	"description" : "MPI File_write_at_all Snippet",
-	"body" : [ "MPI_File_write_at_all( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:void* buf}, ${4:int count}, ${5:MPI_Datatype datatype}, ${6:MPI_Status* status});"]
-},
-
-"MPI_Errhandler_get": {
-	"prefix": ["MPI_Errhandler_get"],
-	"description" : "MPI Errhandler_get Snippet",
-	"body" : [ "MPI_Errhandler_get( ${1:MPI_Comm comm}, ${2:MPI_Errhandler* errhandler});"]
-},
-
-"MPI_Pack_size": {
-	"prefix": ["MPI_Pack_size"],
-	"description" : "MPI Pack_size Snippet",
-	"body" : [ "MPI_Pack_size( ${1:int incount}, ${2:MPI_Datatype datatype}, ${3:MPI_Comm comm}, ${4:int* size});"]
-},
-
-"MPI_Comm_call_errhandler": {
-	"prefix": ["MPI_Comm_call_errhandler"],
-	"description" : "MPI Comm_call_errhandler Snippet",
-	"body" : [ "MPI_Comm_call_errhandler( ${1:MPI_Comm comm}, ${2:int errorcode});"]
-},
-
-"MPI_Comm_test_inter": {
-	"prefix": ["MPI_Comm_test_inter"],
-	"description" : "MPI Comm_test_inter Snippet",
-	"body" : [ "MPI_Comm_test_inter( ${1:MPI_Comm comm}, ${2:int* flag});"]
-},
-
-"MPI_Intercomm_merge": {
-	"prefix": ["MPI_Intercomm_merge"],
-	"description" : "MPI Intercomm_merge Snippet",
-	"body" : [ "MPI_Intercomm_merge( ${1:MPI_Comm intercomm}, ${2:int high}, ${3:MPI_Comm* newintercomm});"]
-},
-
-"MPI_Win_complete": {
-	"prefix": ["MPI_Win_complete"],
-	"description" : "MPI Win_complete Snippet",
-	"body" : [ "MPI_Win_complete( ${1:MPI_Win win});"]
-},
-
-"MPI_File_get_type_extent": {
-	"prefix": ["MPI_File_get_type_extent"],
-	"description" : "MPI File_get_type_extent Snippet",
-	"body" : [ "MPI_File_get_type_extent( ${1:MPI_File fh}, ${2:MPI_Datatype datatype}, ${3:MPI_Aint* extent});"]
-},
-
-"MPI_Graph_map": {
-	"prefix": ["MPI_Graph_map"],
-	"description" : "MPI Graph_map Snippet",
-	"body" : [ "MPI_Graph_map( ${1:MPI_Comm comm}, ${2:int nnodes}, ${3:int index[]}, ${4:int edges[]}, ${5:int* newrank});"]
-},
-
-"MPI_File_read_all_begin": {
-	"prefix": ["MPI_File_read_all_begin"],
-	"description" : "MPI File_read_all_begin Snippet",
-	"body" : [ "MPI_File_read_all_begin( ${1:MPI_File fh}, ${2:void* buf}, ${3:int count}, ${4:MPI_Datatype datatype});"]
-},
-
-"MPI_Info_get_valuelen": {
-	"prefix": ["MPI_Info_get_valuelen"],
-	"description" : "MPI Info_get_valuelen Snippet",
-	"body" : [ "MPI_Info_get_valuelen( ${1:MPI_Info info}, ${2:char* key}, ${3:int* valuelen}, ${4:int* flag});"]
-},
-
-"MPI_Put": {
-	"prefix": ["MPI_Put"],
-	"description" : "MPI Put Snippet",
-	"body" : [ "MPI_Put( ${1:void* origin_addr}, ${2:int origin_count}, ${3:MPI_Datatype origin_datatype}, ${4:int target_rank}, ${5:MPI_Aint target_disp}, ${6:int target_count}, ${7:MPI_Datatype target_datatype}, ${8:MPI_Win win});"]
-},
-
-"MPI_File_read_at_all": {
-	"prefix": ["MPI_File_read_at_all"],
-	"description" : "MPI File_read_at_all Snippet",
-	"body" : [ "MPI_File_read_at_all( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:void* buf}, ${4:int count}, ${5:MPI_Datatype datatype}, ${6:MPI_Status* status});"]
-},
-
-"MPI_File_read_ordered_end": {
-	"prefix": ["MPI_File_read_ordered_end"],
-	"description" : "MPI File_read_ordered_end Snippet",
-	"body" : [ "MPI_File_read_ordered_end( ${1:MPI_File fh}, ${2:void* buf}, ${3:MPI_Status* status});"]
-},
-
-"MPI_Isend": {
-	"prefix": ["MPI_Isend"],
-	"description" : "MPI Isend Snippet",
-	"body" : [ "MPI_Isend( ${1:void* buf}, ${2:int count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
-},
-
-"MPI_Type_set_attr": {
-	"prefix": ["MPI_Type_set_attr"],
-	"description" : "MPI Type_set_attr Snippet",
-	"body" : [ "MPI_Type_set_attr( ${1:MPI_Datatype type}, ${2:int type_keyval}, ${3:void* attr_val});"]
-},
-
-"MPI_Group_rank": {
-	"prefix": ["MPI_Group_rank"],
-	"description" : "MPI Group_rank Snippet",
-	"body" : [ "MPI_Group_rank( ${1:MPI_Group group}, ${2:int* rank});"]
-},
-
-"MPI_Alltoall": {
-	"prefix": ["MPI_Alltoall"],
-	"description" : "MPI Alltoall Snippet",
-	"body" : [ "MPI_Alltoall( ${1:void* sendbuf}, ${2:int sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:int recvcount}, ${6:MPI_Datatype recvtype}, ${7:MPI_Comm comm});"]
-},
-
-"MPI_File_create_errhandler": {
-	"prefix": ["MPI_File_create_errhandler"],
-	"description" : "MPI File_create_errhandler Snippet",
-	"body" : [ "MPI_File_create_errhandler( ${1:MPI_File_errhandler_function* function}, ${2:MPI_Errhandler* errhandler});"]
-},
-
-"MPI_Info_get": {
-	"prefix": ["MPI_Info_get"],
-	"description" : "MPI Info_get Snippet",
-	"body" : [ "MPI_Info_get( ${1:MPI_Info info}, ${2:char* key}, ${3:int valuelen}, ${4:char* value}, ${5:int* flag});"]
-},
-
-"MPI_File_iwrite_at": {
-	"prefix": ["MPI_File_iwrite_at"],
-	"description" : "MPI File_iwrite_at Snippet",
-	"body" : [ "MPI_File_iwrite_at( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:void* buf}, ${4:int count}, ${5:MPI_Datatype datatype}, ${6:MPI_Request* request});"]
-},
-
-"MPI_Group_intersection": {
-	"prefix": ["MPI_Group_intersection"],
-	"description" : "MPI Group_intersection Snippet",
-	"body" : [ "MPI_Group_intersection( ${1:MPI_Group group1}, ${2:MPI_Group group2}, ${3:MPI_Group* newgroup});"]
-},
-
-"MPI_Type_free_keyval": {
-	"prefix": ["MPI_Type_free_keyval"],
-	"description" : "MPI Type_free_keyval Snippet",
-	"body" : [ "MPI_Type_free_keyval( ${1:int* type_keyval});"]
-},
-
-"MPI_Type_create_struct": {
-	"prefix": ["MPI_Type_create_struct"],
-	"description" : "MPI Type_create_struct Snippet",
-	"body" : [ "MPI_Type_create_struct( ${1:int count}, ${2:int array_of_block_lengths[]}, ${3:MPI_Aint array_of_displacements[]}, ${4:MPI_Datatype array_of_types[]}, ${5:MPI_Datatype* newtype});"]
-},
-
-"MPI_Type_get_contents": {
-	"prefix": ["MPI_Type_get_contents"],
-	"description" : "MPI Type_get_contents Snippet",
-	"body" : [ "MPI_Type_get_contents( ${1:MPI_Datatype mtype}, ${2:int max_integers}, ${3:int max_addresses}, ${4:int max_datatypes}, ${5:int array_of_integers[]}, ${6:MPI_Aint array_of_addresses[]}, ${7:MPI_Datatype array_of_datatypes[]});"]
-},
-
-"MPI_Reduce_local": {
-	"prefix": ["MPI_Reduce_local"],
-	"description" : "MPI Reduce_local Snippet",
-	"body" : [ "MPI_Reduce_local( ${1:void* inbuf}, ${2:void* inoutbuf}, ${3:int count}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op});"]
-},
-
-"MPI_Group_union": {
-	"prefix": ["MPI_Group_union"],
-	"description" : "MPI Group_union Snippet",
-	"body" : [ "MPI_Group_union( ${1:MPI_Group group1}, ${2:MPI_Group group2}, ${3:MPI_Group* newgroup});"]
-},
-
-"MPI_Type_free": {
-	"prefix": ["MPI_Type_free"],
-	"description" : "MPI Type_free Snippet",
-	"body" : [ "MPI_Type_free( ${1:MPI_Datatype* type});"]
-},
-
-"MPI_Info_get_nthkey": {
-	"prefix": ["MPI_Info_get_nthkey"],
-	"description" : "MPI Info_get_nthkey Snippet",
-	"body" : [ "MPI_Info_get_nthkey( ${1:MPI_Info info}, ${2:int n}, ${3:char* key});"]
-},
-
-"MPI_Win_get_name": {
-	"prefix": ["MPI_Win_get_name"],
-	"description" : "MPI Win_get_name Snippet",
-	"body" : [ "MPI_Win_get_name( ${1:MPI_Win win}, ${2:char* win_name}, ${3:int* resultlen});"]
-},
-
-"MPI_File_write_at_all_begin": {
-	"prefix": ["MPI_File_write_at_all_begin"],
-	"description" : "MPI File_write_at_all_begin Snippet",
-	"body" : [ "MPI_File_write_at_all_begin( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:void* buf}, ${4:int count}, ${5:MPI_Datatype datatype});"]
-},
-
-"MPI_Unpack_external": {
-	"prefix": ["MPI_Unpack_external"],
-	"description" : "MPI Unpack_external Snippet",
-	"body" : [ "MPI_Unpack_external( ${1:char* datarep}, ${2:void* inbuf}, ${3:MPI_Aint insize}, ${4:MPI_Aint* position}, ${5:void* outbuf}, ${6:int outcount}, ${7:MPI_Datatype datatype});"]
-},
-
-"MPI_Errhandler_set": {
-	"prefix": ["MPI_Errhandler_set"],
-	"description" : "MPI Errhandler_set Snippet",
-	"body" : [ "MPI_Errhandler_set( ${1:MPI_Comm comm}, ${2:MPI_Errhandler errhandler});"]
-},
-
-"MPI_File_read_at_all_begin": {
-	"prefix": ["MPI_File_read_at_all_begin"],
-	"description" : "MPI File_read_at_all_begin Snippet",
-	"body" : [ "MPI_File_read_at_all_begin( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:void* buf}, ${4:int count}, ${5:MPI_Datatype datatype});"]
-},
-
-"MPI_Comm_get_errhandler": {
-	"prefix": ["MPI_Comm_get_errhandler"],
-	"description" : "MPI Comm_get_errhandler Snippet",
-	"body" : [ "MPI_Comm_get_errhandler( ${1:MPI_Comm comm}, ${2:MPI_Errhandler* erhandler});"]
-},
-
-"MPI_Test_cancelled": {
-	"prefix": ["MPI_Test_cancelled"],
-	"description" : "MPI Test_cancelled Snippet",
-	"body" : [ "MPI_Test_cancelled( ${1:MPI_Status* status}, ${2:int* flag});"]
-},
-
-"MPI_Win_lock": {
-	"prefix": ["MPI_Win_lock"],
-	"description" : "MPI Win_lock Snippet",
-	"body" : [ "MPI_Win_lock( ${1:int lock_type}, ${2:int rank}, ${3:int assert}, ${4:MPI_Win win});"]
-},
-
-"MPI_Win_create": {
-	"prefix": ["MPI_Win_create"],
-	"description" : "MPI Win_create Snippet",
-	"body" : [ "MPI_Win_create( ${1:void* base}, ${2:MPI_Aint size}, ${3:int disp_unit}, ${4:MPI_Info info}, ${5:MPI_Comm comm}, ${6:MPI_Win* win});"]
-},
-
-"MPI_Test": {
-	"prefix": ["MPI_Test"],
-	"description" : "MPI Test Snippet",
-	"body" : [ "MPI_Test( ${1:MPI_Request* request}, ${2:int* flag}, ${3:MPI_Status* status});"]
-},
-
-"MPI_Type_create_hvector": {
-	"prefix": ["MPI_Type_create_hvector"],
-	"description" : "MPI Type_create_hvector Snippet",
-	"body" : [ "MPI_Type_create_hvector( ${1:int count}, ${2:int blocklength}, ${3:MPI_Aint stride}, ${4:MPI_Datatype oldtype}, ${5:MPI_Datatype* newtype});"]
-},
-
-"MPI_File_write_all_end": {
-	"prefix": ["MPI_File_write_all_end"],
-	"description" : "MPI File_write_all_end Snippet",
-	"body" : [ "MPI_File_write_all_end( ${1:MPI_File fh}, ${2:void* buf}, ${3:MPI_Status* status});"]
-},
-
-"MPI_Info_get_nkeys": {
-	"prefix": ["MPI_Info_get_nkeys"],
-	"description" : "MPI Info_get_nkeys Snippet",
-	"body" : [ "MPI_Info_get_nkeys( ${1:MPI_Info info}, ${2:int* nkeys});"]
-},
-
-"MPI_Win_start": {
-	"prefix": ["MPI_Win_start"],
-	"description" : "MPI Win_start Snippet",
-	"body" : [ "MPI_Win_start( ${1:MPI_Group group}, ${2:int assert}, ${3:MPI_Win win});"]
-},
-
-"MPI_File_get_size": {
-	"prefix": ["MPI_File_get_size"],
-	"description" : "MPI File_get_size Snippet",
-	"body" : [ "MPI_File_get_size( ${1:MPI_File fh}, ${2:MPI_Offset* size});"]
-},
-
-"MPI_Finalized": {
-	"prefix": ["MPI_Finalized"],
-	"description" : "MPI Finalized Snippet",
-	"body" : [ "MPI_Finalized( ${1:int* flag});"]
-},
-
-"MPI_Win_free_keyval": {
-	"prefix": ["MPI_Win_free_keyval"],
-	"description" : "MPI Win_free_keyval Snippet",
-	"body" : [ "MPI_Win_free_keyval( ${1:int* win_keyval});"]
-},
-
-"MPI_Waitany": {
-	"prefix": ["MPI_Waitany"],
-	"description" : "MPI Waitany Snippet",
-	"body" : [ "MPI_Waitany( ${1:int count}, ${2:MPI_Request array_of_requests[]}, ${3:int* index}, ${4:MPI_Status* status});"]
-},
-
-"MPI_Open_port": {
-	"prefix": ["MPI_Open_port"],
-	"description" : "MPI Open_port Snippet",
-	"body" : [ "MPI_Open_port( ${1:MPI_Info info}, ${2:char* port_name});"]
-},
-
-"MPI_Type_indexed": {
-	"prefix": ["MPI_Type_indexed"],
-	"description" : "MPI Type_indexed Snippet",
-	"body" : [ "MPI_Type_indexed( ${1:int count}, ${2:int array_of_blocklengths[]}, ${3:int array_of_displacements[]}, ${4:MPI_Datatype oldtype}, ${5:MPI_Datatype* newtype});"]
-},
-
-"MPI_Send_init": {
-	"prefix": ["MPI_Send_init"],
-	"description" : "MPI Send_init Snippet",
-	"body" : [ "MPI_Send_init( ${1:void* buf}, ${2:int count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
-},
-
-"MPI_Gather": {
-	"prefix": ["MPI_Gather"],
-	"description" : "MPI Gather Snippet",
-	"body" : [ "MPI_Gather( ${1:void* sendbuf}, ${2:int sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:int recvcount}, ${6:MPI_Datatype recvtype}, ${7:int root}, ${8:MPI_Comm comm});"]
-},
-
-"MPI_Type_vector": {
-	"prefix": ["MPI_Type_vector"],
-	"description" : "MPI Type_vector Snippet",
-	"body" : [ "MPI_Type_vector( ${1:int count}, ${2:int blocklength}, ${3:int stride}, ${4:MPI_Datatype oldtype}, ${5:MPI_Datatype* newtype});"]
-},
-
-"MPI_Get_elements": {
-	"prefix": ["MPI_Get_elements"],
-	"description" : "MPI Get_elements Snippet",
-	"body" : [ "MPI_Get_elements( ${1:MPI_Status* status}, ${2:MPI_Datatype datatype}, ${3:int* count});"]
-},
-
-"MPI_File_write": {
-	"prefix": ["MPI_File_write"],
-	"description" : "MPI File_write Snippet",
-	"body" : [ "MPI_File_write( ${1:MPI_File fh}, ${2:void* buf}, ${3:int count}, ${4:MPI_Datatype datatype}, ${5:MPI_Status* status});"]
-},
-
-"MPI_File_read_at_all_end": {
-	"prefix": ["MPI_File_read_at_all_end"],
-	"description" : "MPI File_read_at_all_end Snippet",
-	"body" : [ "MPI_File_read_at_all_end( ${1:MPI_File fh}, ${2:void* buf}, ${3:MPI_Status* status});"]
-},
-
-"MPI_Probe": {
-	"prefix": ["MPI_Probe"],
-	"description" : "MPI Probe Snippet",
-	"body" : [ "MPI_Probe( ${1:int source}, ${2:int tag}, ${3:MPI_Comm comm}, ${4:MPI_Status* status});"]
-},
-
-"MPI_File_set_view": {
-	"prefix": ["MPI_File_set_view"],
-	"description" : "MPI File_set_view Snippet",
-	"body" : [ "MPI_File_set_view( ${1:MPI_File fh}, ${2:MPI_Offset disp}, ${3:MPI_Datatype etype}, ${4:MPI_Datatype filetype}, ${5:char* datarep}, ${6:MPI_Info info});"]
-},
-
-"MPI_Unpack": {
-	"prefix": ["MPI_Unpack"],
-	"description" : "MPI Unpack Snippet",
-	"body" : [ "MPI_Unpack( ${1:void* inbuf}, ${2:int insize}, ${3:int* position}, ${4:void* outbuf}, ${5:int outcount}, ${6:MPI_Datatype datatype}, ${7:MPI_Comm comm});"]
-},
-
-"MPI_Type_ub": {
-	"prefix": ["MPI_Type_ub"],
-	"description" : "MPI Type_ub Snippet",
-	"body" : [ "MPI_Type_ub( ${1:MPI_Datatype mtype}, ${2:MPI_Aint* ub});"]
-},
-
-"MPI_Status_set_elements": {
-	"prefix": ["MPI_Status_set_elements"],
-	"description" : "MPI Status_set_elements Snippet",
-	"body" : [ "MPI_Status_set_elements( ${1:MPI_Status* status}, ${2:MPI_Datatype datatype}, ${3:int count});"]
-},
-
-"MPI_Win_delete_attr": {
-	"prefix": ["MPI_Win_delete_attr"],
-	"description" : "MPI Win_delete_attr Snippet",
-	"body" : [ "MPI_Win_delete_attr( ${1:MPI_Win win}, ${2:int win_keyval});"]
-},
-
-"MPI_Type_hindexed": {
-	"prefix": ["MPI_Type_hindexed"],
-	"description" : "MPI Type_hindexed Snippet",
-	"body" : [ "MPI_Type_hindexed( ${1:int count}, ${2:int array_of_blocklengths[]}, ${3:MPI_Aint array_of_displacements[]}, ${4:MPI_Datatype oldtype}, ${5:MPI_Datatype* newtype});"]
-},
-
-"MPI_File_set_atomicity": {
-	"prefix": ["MPI_File_set_atomicity"],
-	"description" : "MPI File_set_atomicity Snippet",
-	"body" : [ "MPI_File_set_atomicity( ${1:MPI_File fh}, ${2:int flag});"]
-},
-
-"MPI_Group_range_incl": {
-	"prefix": ["MPI_Group_range_incl"],
-	"description" : "MPI Group_range_incl Snippet",
-	"body" : [ "MPI_Group_range_incl( ${1:MPI_Group group}, ${2:int n}, ${3:int ranges[][3]}, ${4:MPI_Group* newgroup});"]
-},
-
-"MPI_Get": {
-	"prefix": ["MPI_Get"],
-	"description" : "MPI Get Snippet",
-	"body" : [ "MPI_Get( ${1:void* origin_addr}, ${2:int origin_count}, ${3:MPI_Datatype origin_datatype}, ${4:int target_rank}, ${5:MPI_Aint target_disp}, ${6:int target_count}, ${7:MPI_Datatype target_datatype}, ${8:MPI_Win win});"]
-},
-
-"MPI_Iprobe": {
-	"prefix": ["MPI_Iprobe"],
-	"description" : "MPI Iprobe Snippet",
-	"body" : [ "MPI_Iprobe( ${1:int source}, ${2:int tag}, ${3:MPI_Comm comm}, ${4:int* flag}, ${5:MPI_Status* status});"]
-},
-
-"MPI_File_write_at_all_end": {
-	"prefix": ["MPI_File_write_at_all_end"],
-	"description" : "MPI File_write_at_all_end Snippet",
-	"body" : [ "MPI_File_write_at_all_end( ${1:MPI_File fh}, ${2:void* buf}, ${3:MPI_Status* status});"]
-},
-
-"MPI_Type_get_true_extent": {
-	"prefix": ["MPI_Type_get_true_extent"],
-	"description" : "MPI Type_get_true_extent Snippet",
-	"body" : [ "MPI_Type_get_true_extent( ${1:MPI_Datatype datatype}, ${2:MPI_Aint* true_lb}, ${3:MPI_Aint* true_extent});"]
-},
-
-"MPI_Graph_get": {
-	"prefix": ["MPI_Graph_get"],
-	"description" : "MPI Graph_get Snippet",
-	"body" : [ "MPI_Graph_get( ${1:MPI_Comm comm}, ${2:int maxindex}, ${3:int maxedges}, ${4:int index[]}, ${5:int edges[]});"]
-},
-
-"MPI_Info_delete": {
-	"prefix": ["MPI_Info_delete"],
-	"description" : "MPI Info_delete Snippet",
-	"body" : [ "MPI_Info_delete( ${1:MPI_Info info}, ${2:char* key});"]
-},
-
-"MPI_Cart_rank": {
-	"prefix": ["MPI_Cart_rank"],
-	"description" : "MPI Cart_rank Snippet",
-	"body" : [ "MPI_Cart_rank( ${1:MPI_Comm comm}, ${2:int coords[]}, ${3:int* rank});"]
-},
-
-"MPI_Finalize": {
-	"prefix": ["MPI_Finalize"],
-	"description" : "MPI Finalize Snippet",
-	"body" : [ "MPI_Finalize();"]
-},
-
-"MPI_Comm_create": {
-	"prefix": ["MPI_Comm_create"],
-	"description" : "MPI Comm_create Snippet",
-	"body" : [ "MPI_Comm_create( ${1:MPI_Comm comm}, ${2:MPI_Group group}, ${3:MPI_Comm* newcomm});"]
-},
-
-"MPI_Pack_external_size": {
-	"prefix": ["MPI_Pack_external_size"],
-	"description" : "MPI Pack_external_size Snippet",
-	"body" : [ "MPI_Pack_external_size( ${1:char* datarep}, ${2:int incount}, ${3:MPI_Datatype datatype}, ${4:MPI_Aint* size});"]
-},
-
-"MPI_Comm_join": {
-	"prefix": ["MPI_Comm_join"],
-	"description" : "MPI Comm_join Snippet",
-	"body" : [ "MPI_Comm_join( ${1:int fd}, ${2:MPI_Comm* intercomm});"]
-},
-
-"MPI_File_read_at": {
-	"prefix": ["MPI_File_read_at"],
-	"description" : "MPI File_read_at Snippet",
-	"body" : [ "MPI_File_read_at( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:void* buf}, ${4:int count}, ${5:MPI_Datatype datatype}, ${6:MPI_Status* status});"]
-},
-
-"MPI_Keyval_free": {
-	"prefix": ["MPI_Keyval_free"],
-	"description" : "MPI Keyval_free Snippet",
-	"body" : [ "MPI_Keyval_free( ${1:int* keyval});"]
-},
-
-"MPI_Win_wait": {
-	"prefix": ["MPI_Win_wait"],
-	"description" : "MPI Win_wait Snippet",
-	"body" : [ "MPI_Win_wait( ${1:MPI_Win win});"]
+"MPI_Allgatherv_init": {
+	"prefix": ["MPI_Allgatherv_init"],
+	"description" : "MPI Allgatherv_init Snippet",
+	"body" : [ "MPI_Allgatherv_init( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:const MPI_Count recvcounts[]}, ${6:const MPI_Aint displs[]}, ${7:MPI_Datatype recvtype}, ${8:MPI_Comm comm}, ${9:MPI_Info info}, ${10:MPI_Request* request});"]
 },
 
 "MPI_Alloc_mem": {
@@ -1355,148 +71,64 @@
 	"body" : [ "MPI_Alloc_mem( ${1:MPI_Aint size}, ${2:MPI_Info info}, ${3:void* baseptr});"]
 },
 
-"MPI_Improbe": {
-	"prefix": ["MPI_Improbe"],
-	"description" : "MPI Improbe Snippet",
-	"body" : [ "MPI_Improbe( ${1:int source}, ${2:int tag}, ${3:MPI_Comm comm}, ${4:int* flag}, ${5:MPI_Message* message}, ${6:MPI_Status* status});"]
+"MPI_Allreduce": {
+	"prefix": ["MPI_Allreduce"],
+	"description" : "MPI Allreduce Snippet",
+	"body" : [ "MPI_Allreduce( ${1:const void* sendbuf}, ${2:void* recvbuf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:MPI_Comm comm});"]
 },
 
-"MPI_Type_size": {
-	"prefix": ["MPI_Type_size"],
-	"description" : "MPI Type_size Snippet",
-	"body" : [ "MPI_Type_size( ${1:MPI_Datatype type}, ${2:int* size});"]
+"MPI_Allreduce_init": {
+	"prefix": ["MPI_Allreduce_init"],
+	"description" : "MPI Allreduce_init Snippet",
+	"body" : [ "MPI_Allreduce_init( ${1:const void* sendbuf}, ${2:void* recvbuf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:MPI_Comm comm}, ${7:MPI_Info info}, ${8:MPI_Request* request});"]
 },
 
-"MPI_Lookup_name": {
-	"prefix": ["MPI_Lookup_name"],
-	"description" : "MPI Lookup_name Snippet",
-	"body" : [ "MPI_Lookup_name( ${1:char* service_name}, ${2:MPI_Info info}, ${3:char* port_name});"]
+"MPI_Alltoall": {
+	"prefix": ["MPI_Alltoall"],
+	"description" : "MPI Alltoall Snippet",
+	"body" : [ "MPI_Alltoall( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:MPI_Count recvcount}, ${6:MPI_Datatype recvtype}, ${7:MPI_Comm comm});"]
 },
 
-"MPI_File_get_atomicity": {
-	"prefix": ["MPI_File_get_atomicity"],
-	"description" : "MPI File_get_atomicity Snippet",
-	"body" : [ "MPI_File_get_atomicity( ${1:MPI_File fh}, ${2:int* flag});"]
+"MPI_Alltoall_init": {
+	"prefix": ["MPI_Alltoall_init"],
+	"description" : "MPI Alltoall_init Snippet",
+	"body" : [ "MPI_Alltoall_init( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:MPI_Count recvcount}, ${6:MPI_Datatype recvtype}, ${7:MPI_Comm comm}, ${8:MPI_Info info}, ${9:MPI_Request* request});"]
 },
 
-"MPI_File_read_shared": {
-	"prefix": ["MPI_File_read_shared"],
-	"description" : "MPI File_read_shared Snippet",
-	"body" : [ "MPI_File_read_shared( ${1:MPI_File fh}, ${2:void* buf}, ${3:int count}, ${4:MPI_Datatype datatype}, ${5:MPI_Status* status});"]
+"MPI_Alltoallv": {
+	"prefix": ["MPI_Alltoallv"],
+	"description" : "MPI Alltoallv Snippet",
+	"body" : [ "MPI_Alltoallv( ${1:const void* sendbuf}, ${2:const MPI_Count sendcounts[]}, ${3:const MPI_Aint sdispls[]}, ${4:MPI_Datatype sendtype}, ${5:void* recvbuf}, ${6:const MPI_Count recvcounts[]}, ${7:const MPI_Aint rdispls[]}, ${8:MPI_Datatype recvtype}, ${9:MPI_Comm comm});"]
 },
 
-"MPI_Type_create_darray": {
-	"prefix": ["MPI_Type_create_darray"],
-	"description" : "MPI Type_create_darray Snippet",
-	"body" : [ "MPI_Type_create_darray( ${1:int size}, ${2:int rank}, ${3:int ndims}, ${4:int gsize_array[]}, ${5:int distrib_array[]}, ${6:int darg_array[]}, ${7:int psize_array[]}, ${8:int order}, ${9:MPI_Datatype oldtype}, ${10:MPI_Datatype* newtype});"]
+"MPI_Alltoallv_init": {
+	"prefix": ["MPI_Alltoallv_init"],
+	"description" : "MPI Alltoallv_init Snippet",
+	"body" : [ "MPI_Alltoallv_init( ${1:const void* sendbuf}, ${2:const MPI_Count sendcounts[]}, ${3:const MPI_Aint sdispls[]}, ${4:MPI_Datatype sendtype}, ${5:void* recvbuf}, ${6:const MPI_Count recvcounts[]}, ${7:const MPI_Aint rdispls[]}, ${8:MPI_Datatype recvtype}, ${9:MPI_Comm comm}, ${10:MPI_Info info}, ${11:MPI_Request* request});"]
 },
 
-"MPI_Win_create_errhandler": {
-	"prefix": ["MPI_Win_create_errhandler"],
-	"description" : "MPI Win_create_errhandler Snippet",
-	"body" : [ "MPI_Win_create_errhandler( ${1:MPI_Win_errhandler_function* function}, ${2:MPI_Errhandler* errhandler});"]
+"MPI_Alltoallw": {
+	"prefix": ["MPI_Alltoallw"],
+	"description" : "MPI Alltoallw Snippet",
+	"body" : [ "MPI_Alltoallw( ${1:const void* sendbuf}, ${2:const MPI_Count sendcounts[]}, ${3:const MPI_Aint sdispls[]}, ${4:const MPI_Datatype sendtypes[]}, ${5:void* recvbuf}, ${6:const MPI_Count recvcounts[]}, ${7:const MPI_Aint rdispls[]}, ${8:const MPI_Datatype recvtypes[]}, ${9:MPI_Comm comm});"]
 },
 
-"MPI_Cart_map": {
-	"prefix": ["MPI_Cart_map"],
-	"description" : "MPI Cart_map Snippet",
-	"body" : [ "MPI_Cart_map( ${1:MPI_Comm comm}, ${2:int ndims}, ${3:int dims[]}, ${4:int periods[]}, ${5:int* newrank});"]
+"MPI_Alltoallw_init": {
+	"prefix": ["MPI_Alltoallw_init"],
+	"description" : "MPI Alltoallw_init Snippet",
+	"body" : [ "MPI_Alltoallw_init( ${1:const void* sendbuf}, ${2:const MPI_Count sendcounts[]}, ${3:const MPI_Aint sdispls[]}, ${4:const MPI_Datatype sendtypes[]}, ${5:void* recvbuf}, ${6:const MPI_Count recvcounts[]}, ${7:const MPI_Aint rdispls[]}, ${8:const MPI_Datatype recvtypes[]}, ${9:MPI_Comm comm}, ${10:MPI_Info info}, ${11:MPI_Request* request});"]
 },
 
-"MPI_File_write_at": {
-	"prefix": ["MPI_File_write_at"],
-	"description" : "MPI File_write_at Snippet",
-	"body" : [ "MPI_File_write_at( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:void* buf}, ${4:int count}, ${5:MPI_Datatype datatype}, ${6:MPI_Status* status});"]
+"MPI_Attr_delete": {
+	"prefix": ["MPI_Attr_delete"],
+	"description" : "MPI Attr_delete Snippet",
+	"body" : [ "MPI_Attr_delete( ${1:MPI_Comm comm}, ${2:int keyval});"]
 },
 
-"MPI_Comm_accept": {
-	"prefix": ["MPI_Comm_accept"],
-	"description" : "MPI Comm_accept Snippet",
-	"body" : [ "MPI_Comm_accept( ${1:char* port_name}, ${2:MPI_Info info}, ${3:int root}, ${4:MPI_Comm comm}, ${5:MPI_Comm* newcomm});"]
-},
-
-"MPI_Type_set_name": {
-	"prefix": ["MPI_Type_set_name"],
-	"description" : "MPI Type_set_name Snippet",
-	"body" : [ "MPI_Type_set_name( ${1:MPI_Datatype type}, ${2:char* type_name});"]
-},
-
-"MPI_Close_port": {
-	"prefix": ["MPI_Close_port"],
-	"description" : "MPI Close_port Snippet",
-	"body" : [ "MPI_Close_port( ${1:char* port_name});"]
-},
-
-"MPI_File_close": {
-	"prefix": ["MPI_File_close"],
-	"description" : "MPI File_close Snippet",
-	"body" : [ "MPI_File_close( ${1:MPI_File* fh});"]
-},
-
-"MPI_Type_create_subarray": {
-	"prefix": ["MPI_Type_create_subarray"],
-	"description" : "MPI Type_create_subarray Snippet",
-	"body" : [ "MPI_Type_create_subarray( ${1:int ndims}, ${2:int size_array[]}, ${3:int subsize_array[]}, ${4:int start_array[]}, ${5:int order}, ${6:MPI_Datatype oldtype}, ${7:MPI_Datatype* newtype});"]
-},
-
-"MPI_File_delete": {
-	"prefix": ["MPI_File_delete"],
-	"description" : "MPI File_delete Snippet",
-	"body" : [ "MPI_File_delete( ${1:char* filename}, ${2:MPI_Info info});"]
-},
-
-"MPI_Comm_set_attr": {
-	"prefix": ["MPI_Comm_set_attr"],
-	"description" : "MPI Comm_set_attr Snippet",
-	"body" : [ "MPI_Comm_set_attr( ${1:MPI_Comm comm}, ${2:int comm_keyval}, ${3:void* attribute_val});"]
-},
-
-"MPI_File_read_all": {
-	"prefix": ["MPI_File_read_all"],
-	"description" : "MPI File_read_all Snippet",
-	"body" : [ "MPI_File_read_all( ${1:MPI_File fh}, ${2:void* buf}, ${3:int count}, ${4:MPI_Datatype datatype}, ${5:MPI_Status* status});"]
-},
-
-"MPI_Recv": {
-	"prefix": ["MPI_Recv"],
-	"description" : "MPI Recv Snippet",
-	"body" : [ "MPI_Recv( ${1:void* buf}, ${2:int count}, ${3:MPI_Datatype datatype}, ${4:int source}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Status* status});"]
-},
-
-"MPI_Comm_dup": {
-	"prefix": ["MPI_Comm_dup"],
-	"description" : "MPI Comm_dup Snippet",
-	"body" : [ "MPI_Comm_dup( ${1:MPI_Comm comm}, ${2:MPI_Comm* newcomm});"]
-},
-
-"MPI_Waitall": {
-	"prefix": ["MPI_Waitall"],
-	"description" : "MPI Waitall Snippet",
-	"body" : [ "MPI_Waitall( ${1:int count}, ${2:MPI_Request array_of_requests[]}, ${3:MPI_Status array_of_statuses[]});"]
-},
-
-"MPI_Comm_delete_attr": {
-	"prefix": ["MPI_Comm_delete_attr"],
-	"description" : "MPI Comm_delete_attr Snippet",
-	"body" : [ "MPI_Comm_delete_attr( ${1:MPI_Comm comm}, ${2:int comm_keyval});"]
-},
-
-"MPI_Ssend": {
-	"prefix": ["MPI_Ssend"],
-	"description" : "MPI Ssend Snippet",
-	"body" : [ "MPI_Ssend( ${1:void* buf}, ${2:int count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm});"]
-},
-
-"MPI_Group_size": {
-	"prefix": ["MPI_Group_size"],
-	"description" : "MPI Group_size Snippet",
-	"body" : [ "MPI_Group_size( ${1:MPI_Group group}, ${2:int* size});"]
-},
-
-"MPI_File_get_errhandler": {
-	"prefix": ["MPI_File_get_errhandler"],
-	"description" : "MPI File_get_errhandler Snippet",
-	"body" : [ "MPI_File_get_errhandler( ${1:MPI_File file}, ${2:MPI_Errhandler* errhandler});"]
+"MPI_Attr_get": {
+	"prefix": ["MPI_Attr_get"],
+	"description" : "MPI Attr_get Snippet",
+	"body" : [ "MPI_Attr_get( ${1:MPI_Comm comm}, ${2:int keyval}, ${3:void* attribute_val}, ${4:int* flag});"]
 },
 
 "MPI_Attr_put": {
@@ -1511,130 +143,46 @@
 	"body" : [ "MPI_Barrier( ${1:MPI_Comm comm});"]
 },
 
-"MPI_Win_free": {
-	"prefix": ["MPI_Win_free"],
-	"description" : "MPI Win_free Snippet",
-	"body" : [ "MPI_Win_free( ${1:MPI_Win* win});"]
+"MPI_Barrier_init": {
+	"prefix": ["MPI_Barrier_init"],
+	"description" : "MPI Barrier_init Snippet",
+	"body" : [ "MPI_Barrier_init( ${1:MPI_Comm comm}, ${2:MPI_Info info}, ${3:MPI_Request* request});"]
 },
 
-"MPI_Alltoallw": {
-	"prefix": ["MPI_Alltoallw"],
-	"description" : "MPI Alltoallw Snippet",
-	"body" : [ "MPI_Alltoallw( ${1:void* sendbuf}, ${2:int sendcounts[]}, ${3:int sdispls[]}, ${4:MPI_Datatype sendtypes[]}, ${5:void* recvbuf}, ${6:int recvcounts[]}, ${7:int rdispls[]}, ${8:MPI_Datatype recvtypes[]}, ${9:MPI_Comm comm});"]
+"MPI_Bcast": {
+	"prefix": ["MPI_Bcast"],
+	"description" : "MPI Bcast Snippet",
+	"body" : [ "MPI_Bcast( ${1:void* buffer}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int root}, ${5:MPI_Comm comm});"]
 },
 
-"MPI_Alltoallv": {
-	"prefix": ["MPI_Alltoallv"],
-	"description" : "MPI Alltoallv Snippet",
-	"body" : [ "MPI_Alltoallv( ${1:void* sendbuf}, ${2:int sendcounts[]}, ${3:int sdispls[]}, ${4:MPI_Datatype sendtype}, ${5:void* recvbuf}, ${6:int recvcounts[]}, ${7:int rdispls[]}, ${8:MPI_Datatype recvtype}, ${9:MPI_Comm comm});"]
+"MPI_Bcast_init": {
+	"prefix": ["MPI_Bcast_init"],
+	"description" : "MPI Bcast_init Snippet",
+	"body" : [ "MPI_Bcast_init( ${1:void* buffer}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int root}, ${5:MPI_Comm comm}, ${6:MPI_Info info}, ${7:MPI_Request* request});"]
+},
+
+"MPI_Bsend": {
+	"prefix": ["MPI_Bsend"],
+	"description" : "MPI Bsend Snippet",
+	"body" : [ "MPI_Bsend( ${1:const void* buf}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm});"]
 },
 
 "MPI_Bsend_init": {
 	"prefix": ["MPI_Bsend_init"],
 	"description" : "MPI Bsend_init Snippet",
-	"body" : [ "MPI_Bsend_init( ${1:void* buf}, ${2:int count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
+	"body" : [ "MPI_Bsend_init( ${1:const void* buf}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
 },
 
-"MPI_Exscan": {
-	"prefix": ["MPI_Exscan"],
-	"description" : "MPI Exscan Snippet",
-	"body" : [ "MPI_Exscan( ${1:void* sendbuf}, ${2:void* recvbuf}, ${3:int count}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:MPI_Comm comm});"]
+"MPI_Buffer_attach": {
+	"prefix": ["MPI_Buffer_attach"],
+	"description" : "MPI Buffer_attach Snippet",
+	"body" : [ "MPI_Buffer_attach( ${1:void* buffer}, ${2:MPI_Count size});"]
 },
 
-"MPI_Op_free": {
-	"prefix": ["MPI_Op_free"],
-	"description" : "MPI Op_free Snippet",
-	"body" : [ "MPI_Op_free( ${1:MPI_Op* op});"]
-},
-
-"MPI_Win_set_errhandler": {
-	"prefix": ["MPI_Win_set_errhandler"],
-	"description" : "MPI Win_set_errhandler Snippet",
-	"body" : [ "MPI_Win_set_errhandler( ${1:MPI_Win win}, ${2:MPI_Errhandler errhandler});"]
-},
-
-"MPI_Accumulate": {
-	"prefix": ["MPI_Accumulate"],
-	"description" : "MPI Accumulate Snippet",
-	"body" : [ "MPI_Accumulate( ${1:void* origin_addr}, ${2:int origin_count}, ${3:MPI_Datatype origin_datatype}, ${4:int target_rank}, ${5:MPI_Aint target_disp}, ${6:int target_count}, ${7:MPI_Datatype target_datatype}, ${8:MPI_Op op}, ${9:MPI_Win win});"]
-},
-
-"MPI_Comm_get_name": {
-	"prefix": ["MPI_Comm_get_name"],
-	"description" : "MPI Comm_get_name Snippet",
-	"body" : [ "MPI_Comm_get_name( ${1:MPI_Comm comm}, ${2:char* comm_name}, ${3:int* resultlen});"]
-},
-
-"MPI_Cart_sub": {
-	"prefix": ["MPI_Cart_sub"],
-	"description" : "MPI Cart_sub Snippet",
-	"body" : [ "MPI_Cart_sub( ${1:MPI_Comm comm}, ${2:int remain_dims[]}, ${3:MPI_Comm* new_comm});"]
-},
-
-"MPI_File_write_ordered": {
-	"prefix": ["MPI_File_write_ordered"],
-	"description" : "MPI File_write_ordered Snippet",
-	"body" : [ "MPI_File_write_ordered( ${1:MPI_File fh}, ${2:void* buf}, ${3:int count}, ${4:MPI_Datatype datatype}, ${5:MPI_Status* status});"]
-},
-
-"MPI_Group_range_excl": {
-	"prefix": ["MPI_Group_range_excl"],
-	"description" : "MPI Group_range_excl Snippet",
-	"body" : [ "MPI_Group_range_excl( ${1:MPI_Group group}, ${2:int n}, ${3:int ranges[][3]}, ${4:MPI_Group* newgroup});"]
-},
-
-"MPI_Comm_split": {
-	"prefix": ["MPI_Comm_split"],
-	"description" : "MPI Comm_split Snippet",
-	"body" : [ "MPI_Comm_split( ${1:MPI_Comm comm}, ${2:int color}, ${3:int key}, ${4:MPI_Comm* newcomm});"]
-},
-
-"MPI_Comm_set_errhandler": {
-	"prefix": ["MPI_Comm_set_errhandler"],
-	"description" : "MPI Comm_set_errhandler Snippet",
-	"body" : [ "MPI_Comm_set_errhandler( ${1:MPI_Comm comm}, ${2:MPI_Errhandler errhandler});"]
-},
-
-"MPI_Request_get_status": {
-	"prefix": ["MPI_Request_get_status"],
-	"description" : "MPI Request_get_status Snippet",
-	"body" : [ "MPI_Request_get_status( ${1:MPI_Request request}, ${2:int* flag}, ${3:MPI_Status* status});"]
-},
-
-"MPI_Group_free": {
-	"prefix": ["MPI_Group_free"],
-	"description" : "MPI Group_free Snippet",
-	"body" : [ "MPI_Group_free( ${1:MPI_Group* group});"]
-},
-
-"MPI_Type_create_keyval": {
-	"prefix": ["MPI_Type_create_keyval"],
-	"description" : "MPI Type_create_keyval Snippet",
-	"body" : [ "MPI_Type_create_keyval( ${1:MPI_Type_copy_attr_function* type_copy_attr_fn}, ${2:MPI_Type_delete_attr_function* type_delete_attr_fn}, ${3:int* type_keyval}, ${4:void* extra_state});"]
-},
-
-"MPI_File_write_ordered_begin": {
-	"prefix": ["MPI_File_write_ordered_begin"],
-	"description" : "MPI File_write_ordered_begin Snippet",
-	"body" : [ "MPI_File_write_ordered_begin( ${1:MPI_File fh}, ${2:void* buf}, ${3:int count}, ${4:MPI_Datatype datatype});"]
-},
-
-"MPI_File_read_ordered_begin": {
-	"prefix": ["MPI_File_read_ordered_begin"],
-	"description" : "MPI File_read_ordered_begin Snippet",
-	"body" : [ "MPI_File_read_ordered_begin( ${1:MPI_File fh}, ${2:void* buf}, ${3:int count}, ${4:MPI_Datatype datatype});"]
-},
-
-"MPI_Graphdims_get": {
-	"prefix": ["MPI_Graphdims_get"],
-	"description" : "MPI Graphdims_get Snippet",
-	"body" : [ "MPI_Graphdims_get( ${1:MPI_Comm comm}, ${2:int* nnodes}, ${3:int* nedges});"]
-},
-
-"MPI_Comm_rank": {
-	"prefix": ["MPI_Comm_rank"],
-	"description" : "MPI Comm_rank Snippet",
-	"body" : [ "MPI_Comm_rank( ${1:MPI_Comm comm}, ${2:int* rank});"]
+"MPI_Buffer_detach": {
+	"prefix": ["MPI_Buffer_detach"],
+	"description" : "MPI Buffer_detach Snippet",
+	"body" : [ "MPI_Buffer_detach( ${1:void* buffer_addr}, ${2:MPI_Count* size});"]
 },
 
 "MPI_Cancel": {
@@ -1643,16 +191,316 @@
 	"body" : [ "MPI_Cancel( ${1:MPI_Request* request});"]
 },
 
-"MPI_Win_fence": {
-	"prefix": ["MPI_Win_fence"],
-	"description" : "MPI Win_fence Snippet",
-	"body" : [ "MPI_Win_fence( ${1:int assert}, ${2:MPI_Win win});"]
+"MPI_Cart_coords": {
+	"prefix": ["MPI_Cart_coords"],
+	"description" : "MPI Cart_coords Snippet",
+	"body" : [ "MPI_Cart_coords( ${1:MPI_Comm comm}, ${2:int rank}, ${3:int maxdims}, ${4:int coords[]});"]
 },
 
-"MPI_Win_create_keyval": {
-	"prefix": ["MPI_Win_create_keyval"],
-	"description" : "MPI Win_create_keyval Snippet",
-	"body" : [ "MPI_Win_create_keyval( ${1:MPI_Win_copy_attr_function* win_copy_attr_fn}, ${2:MPI_Win_delete_attr_function* win_delete_attr_fn}, ${3:int* win_keyval}, ${4:void* extra_state});"]
+"MPI_Cart_create": {
+	"prefix": ["MPI_Cart_create"],
+	"description" : "MPI Cart_create Snippet",
+	"body" : [ "MPI_Cart_create( ${1:MPI_Comm comm_old}, ${2:int ndims}, ${3:const int dims[]}, ${4:const int periods[]}, ${5:int reorder}, ${6:MPI_Comm* comm_cart});"]
+},
+
+"MPI_Cart_get": {
+	"prefix": ["MPI_Cart_get"],
+	"description" : "MPI Cart_get Snippet",
+	"body" : [ "MPI_Cart_get( ${1:MPI_Comm comm}, ${2:int maxdims}, ${3:int dims[]}, ${4:int periods[]}, ${5:int coords[]});"]
+},
+
+"MPI_Cart_map": {
+	"prefix": ["MPI_Cart_map"],
+	"description" : "MPI Cart_map Snippet",
+	"body" : [ "MPI_Cart_map( ${1:MPI_Comm comm}, ${2:int ndims}, ${3:const int dims[]}, ${4:const int periods[]}, ${5:int* newrank});"]
+},
+
+"MPI_Cart_rank": {
+	"prefix": ["MPI_Cart_rank"],
+	"description" : "MPI Cart_rank Snippet",
+	"body" : [ "MPI_Cart_rank( ${1:MPI_Comm comm}, ${2:const int coords[]}, ${3:int* rank});"]
+},
+
+"MPI_Cart_shift": {
+	"prefix": ["MPI_Cart_shift"],
+	"description" : "MPI Cart_shift Snippet",
+	"body" : [ "MPI_Cart_shift( ${1:MPI_Comm comm}, ${2:int direction}, ${3:int disp}, ${4:int* rank_source}, ${5:int* rank_dest});"]
+},
+
+"MPI_Cart_sub": {
+	"prefix": ["MPI_Cart_sub"],
+	"description" : "MPI Cart_sub Snippet",
+	"body" : [ "MPI_Cart_sub( ${1:MPI_Comm comm}, ${2:const int remain_dims[]}, ${3:MPI_Comm* newcomm});"]
+},
+
+"MPI_Cartdim_get": {
+	"prefix": ["MPI_Cartdim_get"],
+	"description" : "MPI Cartdim_get Snippet",
+	"body" : [ "MPI_Cartdim_get( ${1:MPI_Comm comm}, ${2:int* ndims});"]
+},
+
+"MPI_Close_port": {
+	"prefix": ["MPI_Close_port"],
+	"description" : "MPI Close_port Snippet",
+	"body" : [ "MPI_Close_port( ${1:const char* port_name});"]
+},
+
+"MPI_Comm_accept": {
+	"prefix": ["MPI_Comm_accept"],
+	"description" : "MPI Comm_accept Snippet",
+	"body" : [ "MPI_Comm_accept( ${1:const char* port_name}, ${2:MPI_Info info}, ${3:int root}, ${4:MPI_Comm comm}, ${5:MPI_Comm* newcomm});"]
+},
+
+"MPI_Comm_call_errhandler": {
+	"prefix": ["MPI_Comm_call_errhandler"],
+	"description" : "MPI Comm_call_errhandler Snippet",
+	"body" : [ "MPI_Comm_call_errhandler( ${1:MPI_Comm comm}, ${2:int errorcode});"]
+},
+
+"MPI_Comm_compare": {
+	"prefix": ["MPI_Comm_compare"],
+	"description" : "MPI Comm_compare Snippet",
+	"body" : [ "MPI_Comm_compare( ${1:MPI_Comm comm1}, ${2:MPI_Comm comm2}, ${3:int* result});"]
+},
+
+"MPI_Comm_connect": {
+	"prefix": ["MPI_Comm_connect"],
+	"description" : "MPI Comm_connect Snippet",
+	"body" : [ "MPI_Comm_connect( ${1:const char* port_name}, ${2:MPI_Info info}, ${3:int root}, ${4:MPI_Comm comm}, ${5:MPI_Comm* newcomm});"]
+},
+
+"MPI_Comm_create": {
+	"prefix": ["MPI_Comm_create"],
+	"description" : "MPI Comm_create Snippet",
+	"body" : [ "MPI_Comm_create( ${1:MPI_Comm comm}, ${2:MPI_Group group}, ${3:MPI_Comm* newcomm});"]
+},
+
+"MPI_Comm_create_errhandler": {
+	"prefix": ["MPI_Comm_create_errhandler"],
+	"description" : "MPI Comm_create_errhandler Snippet",
+	"body" : [ "MPI_Comm_create_errhandler( ${1:MPI_Comm_errhandler_function* comm_errhandler_fn}, ${2:MPI_Errhandler* errhandler});"]
+},
+
+"MPI_Comm_create_from_group": {
+	"prefix": ["MPI_Comm_create_from_group"],
+	"description" : "MPI Comm_create_from_group Snippet",
+	"body" : [ "MPI_Comm_create_from_group( ${1:MPI_Group group}, ${2:const char* stringtag}, ${3:MPI_Info info}, ${4:MPI_Errhandler errhandler}, ${5:MPI_Comm* newcomm});"]
+},
+
+"MPI_Comm_create_group": {
+	"prefix": ["MPI_Comm_create_group"],
+	"description" : "MPI Comm_create_group Snippet",
+	"body" : [ "MPI_Comm_create_group( ${1:MPI_Comm comm}, ${2:MPI_Group group}, ${3:int tag}, ${4:MPI_Comm* newcomm});"]
+},
+
+"MPI_Comm_create_keyval": {
+	"prefix": ["MPI_Comm_create_keyval"],
+	"description" : "MPI Comm_create_keyval Snippet",
+	"body" : [ "MPI_Comm_create_keyval( ${1:MPI_Comm_copy_attr_function* comm_copy_attr_fn}, ${2:MPI_Comm_delete_attr_function* comm_delete_attr_fn}, ${3:int* comm_keyval}, ${4:void* extra_state});"]
+},
+
+"MPI_Comm_delete_attr": {
+	"prefix": ["MPI_Comm_delete_attr"],
+	"description" : "MPI Comm_delete_attr Snippet",
+	"body" : [ "MPI_Comm_delete_attr( ${1:MPI_Comm comm}, ${2:int comm_keyval});"]
+},
+
+"MPI_Comm_disconnect": {
+	"prefix": ["MPI_Comm_disconnect"],
+	"description" : "MPI Comm_disconnect Snippet",
+	"body" : [ "MPI_Comm_disconnect( ${1:MPI_Comm* comm});"]
+},
+
+"MPI_Comm_dup": {
+	"prefix": ["MPI_Comm_dup"],
+	"description" : "MPI Comm_dup Snippet",
+	"body" : [ "MPI_Comm_dup( ${1:MPI_Comm comm}, ${2:MPI_Comm* newcomm});"]
+},
+
+"MPI_Comm_dup_with_info": {
+	"prefix": ["MPI_Comm_dup_with_info"],
+	"description" : "MPI Comm_dup_with_info Snippet",
+	"body" : [ "MPI_Comm_dup_with_info( ${1:MPI_Comm comm}, ${2:MPI_Info info}, ${3:MPI_Comm* newcomm});"]
+},
+
+"MPI_Comm_free": {
+	"prefix": ["MPI_Comm_free"],
+	"description" : "MPI Comm_free Snippet",
+	"body" : [ "MPI_Comm_free( ${1:MPI_Comm* comm});"]
+},
+
+"MPI_Comm_free_keyval": {
+	"prefix": ["MPI_Comm_free_keyval"],
+	"description" : "MPI Comm_free_keyval Snippet",
+	"body" : [ "MPI_Comm_free_keyval( ${1:int* comm_keyval});"]
+},
+
+"MPI_Comm_get_attr": {
+	"prefix": ["MPI_Comm_get_attr"],
+	"description" : "MPI Comm_get_attr Snippet",
+	"body" : [ "MPI_Comm_get_attr( ${1:MPI_Comm comm}, ${2:int comm_keyval}, ${3:void* attribute_val}, ${4:int* flag});"]
+},
+
+"MPI_Comm_get_errhandler": {
+	"prefix": ["MPI_Comm_get_errhandler"],
+	"description" : "MPI Comm_get_errhandler Snippet",
+	"body" : [ "MPI_Comm_get_errhandler( ${1:MPI_Comm comm}, ${2:MPI_Errhandler* errhandler});"]
+},
+
+"MPI_Comm_get_info": {
+	"prefix": ["MPI_Comm_get_info"],
+	"description" : "MPI Comm_get_info Snippet",
+	"body" : [ "MPI_Comm_get_info( ${1:MPI_Comm comm}, ${2:MPI_Info* info_used});"]
+},
+
+"MPI_Comm_get_name": {
+	"prefix": ["MPI_Comm_get_name"],
+	"description" : "MPI Comm_get_name Snippet",
+	"body" : [ "MPI_Comm_get_name( ${1:MPI_Comm comm}, ${2:char* comm_name}, ${3:int* resultlen});"]
+},
+
+"MPI_Comm_get_parent": {
+	"prefix": ["MPI_Comm_get_parent"],
+	"description" : "MPI Comm_get_parent Snippet",
+	"body" : [ "MPI_Comm_get_parent( ${1:MPI_Comm* parent});"]
+},
+
+"MPI_Comm_group": {
+	"prefix": ["MPI_Comm_group"],
+	"description" : "MPI Comm_group Snippet",
+	"body" : [ "MPI_Comm_group( ${1:MPI_Comm comm}, ${2:MPI_Group* group});"]
+},
+
+"MPI_Comm_idup": {
+	"prefix": ["MPI_Comm_idup"],
+	"description" : "MPI Comm_idup Snippet",
+	"body" : [ "MPI_Comm_idup( ${1:MPI_Comm comm}, ${2:MPI_Comm* newcomm}, ${3:MPI_Request* request});"]
+},
+
+"MPI_Comm_idup_with_info": {
+	"prefix": ["MPI_Comm_idup_with_info"],
+	"description" : "MPI Comm_idup_with_info Snippet",
+	"body" : [ "MPI_Comm_idup_with_info( ${1:MPI_Comm comm}, ${2:MPI_Info info}, ${3:MPI_Comm* newcomm}, ${4:MPI_Request* request});"]
+},
+
+"MPI_Comm_join": {
+	"prefix": ["MPI_Comm_join"],
+	"description" : "MPI Comm_join Snippet",
+	"body" : [ "MPI_Comm_join( ${1:int fd}, ${2:MPI_Comm* intercomm});"]
+},
+
+"MPI_Comm_rank": {
+	"prefix": ["MPI_Comm_rank"],
+	"description" : "MPI Comm_rank Snippet",
+	"body" : [ "MPI_Comm_rank( ${1:MPI_Comm comm}, ${2:int* rank});"]
+},
+
+"MPI_Comm_remote_group": {
+	"prefix": ["MPI_Comm_remote_group"],
+	"description" : "MPI Comm_remote_group Snippet",
+	"body" : [ "MPI_Comm_remote_group( ${1:MPI_Comm comm}, ${2:MPI_Group* group});"]
+},
+
+"MPI_Comm_remote_size": {
+	"prefix": ["MPI_Comm_remote_size"],
+	"description" : "MPI Comm_remote_size Snippet",
+	"body" : [ "MPI_Comm_remote_size( ${1:MPI_Comm comm}, ${2:int* size});"]
+},
+
+"MPI_Comm_set_attr": {
+	"prefix": ["MPI_Comm_set_attr"],
+	"description" : "MPI Comm_set_attr Snippet",
+	"body" : [ "MPI_Comm_set_attr( ${1:MPI_Comm comm}, ${2:int comm_keyval}, ${3:void* attribute_val});"]
+},
+
+"MPI_Comm_set_errhandler": {
+	"prefix": ["MPI_Comm_set_errhandler"],
+	"description" : "MPI Comm_set_errhandler Snippet",
+	"body" : [ "MPI_Comm_set_errhandler( ${1:MPI_Comm comm}, ${2:MPI_Errhandler errhandler});"]
+},
+
+"MPI_Comm_set_info": {
+	"prefix": ["MPI_Comm_set_info"],
+	"description" : "MPI Comm_set_info Snippet",
+	"body" : [ "MPI_Comm_set_info( ${1:MPI_Comm comm}, ${2:MPI_Info info});"]
+},
+
+"MPI_Comm_set_name": {
+	"prefix": ["MPI_Comm_set_name"],
+	"description" : "MPI Comm_set_name Snippet",
+	"body" : [ "MPI_Comm_set_name( ${1:MPI_Comm comm}, ${2:const char* comm_name});"]
+},
+
+"MPI_Comm_size": {
+	"prefix": ["MPI_Comm_size"],
+	"description" : "MPI Comm_size Snippet",
+	"body" : [ "MPI_Comm_size( ${1:MPI_Comm comm}, ${2:int* size});"]
+},
+
+"MPI_Comm_spawn": {
+	"prefix": ["MPI_Comm_spawn"],
+	"description" : "MPI Comm_spawn Snippet",
+	"body" : [ "MPI_Comm_spawn( ${1:const char* command}, ${2:char* argv[]}, ${3:int maxprocs}, ${4:MPI_Info info}, ${5:int root}, ${6:MPI_Comm comm}, ${7:MPI_Comm* intercomm}, ${8:int array_of_errcodes[]});"]
+},
+
+"MPI_Comm_spawn_multiple": {
+	"prefix": ["MPI_Comm_spawn_multiple"],
+	"description" : "MPI Comm_spawn_multiple Snippet",
+	"body" : [ "MPI_Comm_spawn_multiple( ${1:int count}, ${2:char* array_of_commands[]}, ${3:char** array_of_argv[]}, ${4:const int array_of_maxprocs[]}, ${5:const MPI_Info array_of_info[]}, ${6:int root}, ${7:MPI_Comm comm}, ${8:MPI_Comm* intercomm}, ${9:int array_of_errcodes[]});"]
+},
+
+"MPI_Comm_split": {
+	"prefix": ["MPI_Comm_split"],
+	"description" : "MPI Comm_split Snippet",
+	"body" : [ "MPI_Comm_split( ${1:MPI_Comm comm}, ${2:int color}, ${3:int key}, ${4:MPI_Comm* newcomm});"]
+},
+
+"MPI_Comm_split_type": {
+	"prefix": ["MPI_Comm_split_type"],
+	"description" : "MPI Comm_split_type Snippet",
+	"body" : [ "MPI_Comm_split_type( ${1:MPI_Comm comm}, ${2:int split_type}, ${3:int key}, ${4:MPI_Info info}, ${5:MPI_Comm* newcomm});"]
+},
+
+"MPI_Comm_test_inter": {
+	"prefix": ["MPI_Comm_test_inter"],
+	"description" : "MPI Comm_test_inter Snippet",
+	"body" : [ "MPI_Comm_test_inter( ${1:MPI_Comm comm}, ${2:int* flag});"]
+},
+
+"MPI_Compare_and_swap": {
+	"prefix": ["MPI_Compare_and_swap"],
+	"description" : "MPI Compare_and_swap Snippet",
+	"body" : [ "MPI_Compare_and_swap( ${1:const void* origin_addr}, ${2:const void* compare_addr}, ${3:void* result_addr}, ${4:MPI_Datatype datatype}, ${5:int target_rank}, ${6:MPI_Aint target_disp}, ${7:MPI_Win win});"]
+},
+
+"MPI_Dims_create": {
+	"prefix": ["MPI_Dims_create"],
+	"description" : "MPI Dims_create Snippet",
+	"body" : [ "MPI_Dims_create( ${1:int nnodes}, ${2:int ndims}, ${3:int dims[]});"]
+},
+
+"MPI_Dist_graph_create": {
+	"prefix": ["MPI_Dist_graph_create"],
+	"description" : "MPI Dist_graph_create Snippet",
+	"body" : [ "MPI_Dist_graph_create( ${1:MPI_Comm comm_old}, ${2:int n}, ${3:const int sources[]}, ${4:const int degrees[]}, ${5:const int destinations[]}, ${6:const int weights[]}, ${7:MPI_Info info}, ${8:int reorder}, ${9:MPI_Comm* comm_dist_graph});"]
+},
+
+"MPI_Dist_graph_create_adjacent": {
+	"prefix": ["MPI_Dist_graph_create_adjacent"],
+	"description" : "MPI Dist_graph_create_adjacent Snippet",
+	"body" : [ "MPI_Dist_graph_create_adjacent( ${1:MPI_Comm comm_old}, ${2:int indegree}, ${3:const int sources[]}, ${4:const int sourceweights[]}, ${5:int outdegree}, ${6:const int destinations[]}, ${7:const int destweights[]}, ${8:MPI_Info info}, ${9:int reorder}, ${10:MPI_Comm* comm_dist_graph});"]
+},
+
+"MPI_Dist_graph_neighbors": {
+	"prefix": ["MPI_Dist_graph_neighbors"],
+	"description" : "MPI Dist_graph_neighbors Snippet",
+	"body" : [ "MPI_Dist_graph_neighbors( ${1:MPI_Comm comm}, ${2:int maxindegree}, ${3:int sources[]}, ${4:int sourceweights[]}, ${5:int maxoutdegree}, ${6:int destinations[]}, ${7:int destweights[]});"]
+},
+
+"MPI_Dist_graph_neighbors_count": {
+	"prefix": ["MPI_Dist_graph_neighbors_count"],
+	"description" : "MPI Dist_graph_neighbors_count Snippet",
+	"body" : [ "MPI_Dist_graph_neighbors_count( ${1:MPI_Comm comm}, ${2:int* indegree}, ${3:int* outdegree}, ${4:int* weighted});"]
 },
 
 "MPI_Errhandler_free": {
@@ -1661,28 +509,2200 @@
 	"body" : [ "MPI_Errhandler_free( ${1:MPI_Errhandler* errhandler});"]
 },
 
+"MPI_Error_class": {
+	"prefix": ["MPI_Error_class"],
+	"description" : "MPI Error_class Snippet",
+	"body" : [ "MPI_Error_class( ${1:int errorcode}, ${2:int* errorclass});"]
+},
+
+"MPI_Error_string": {
+	"prefix": ["MPI_Error_string"],
+	"description" : "MPI Error_string Snippet",
+	"body" : [ "MPI_Error_string( ${1:int errorcode}, ${2:char* string}, ${3:int* resultlen});"]
+},
+
+"MPI_Exscan": {
+	"prefix": ["MPI_Exscan"],
+	"description" : "MPI Exscan Snippet",
+	"body" : [ "MPI_Exscan( ${1:const void* sendbuf}, ${2:void* recvbuf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:MPI_Comm comm});"]
+},
+
+"MPI_Exscan_init": {
+	"prefix": ["MPI_Exscan_init"],
+	"description" : "MPI Exscan_init Snippet",
+	"body" : [ "MPI_Exscan_init( ${1:const void* sendbuf}, ${2:void* recvbuf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:MPI_Comm comm}, ${7:MPI_Info info}, ${8:MPI_Request* request});"]
+},
+
+"MPI_Fetch_and_op": {
+	"prefix": ["MPI_Fetch_and_op"],
+	"description" : "MPI Fetch_and_op Snippet",
+	"body" : [ "MPI_Fetch_and_op( ${1:const void* origin_addr}, ${2:void* result_addr}, ${3:MPI_Datatype datatype}, ${4:int target_rank}, ${5:MPI_Aint target_disp}, ${6:MPI_Op op}, ${7:MPI_Win win});"]
+},
+
+"MPI_File_call_errhandler": {
+	"prefix": ["MPI_File_call_errhandler"],
+	"description" : "MPI File_call_errhandler Snippet",
+	"body" : [ "MPI_File_call_errhandler( ${1:MPI_File fh}, ${2:int errorcode});"]
+},
+
+"MPI_File_close": {
+	"prefix": ["MPI_File_close"],
+	"description" : "MPI File_close Snippet",
+	"body" : [ "MPI_File_close( ${1:MPI_File* fh});"]
+},
+
+"MPI_File_create_errhandler": {
+	"prefix": ["MPI_File_create_errhandler"],
+	"description" : "MPI File_create_errhandler Snippet",
+	"body" : [ "MPI_File_create_errhandler( ${1:MPI_File_errhandler_function* file_errhandler_fn}, ${2:MPI_Errhandler* errhandler});"]
+},
+
+"MPI_File_delete": {
+	"prefix": ["MPI_File_delete"],
+	"description" : "MPI File_delete Snippet",
+	"body" : [ "MPI_File_delete( ${1:const char* filename}, ${2:MPI_Info info});"]
+},
+
+"MPI_File_get_amode": {
+	"prefix": ["MPI_File_get_amode"],
+	"description" : "MPI File_get_amode Snippet",
+	"body" : [ "MPI_File_get_amode( ${1:MPI_File fh}, ${2:int* amode});"]
+},
+
+"MPI_File_get_atomicity": {
+	"prefix": ["MPI_File_get_atomicity"],
+	"description" : "MPI File_get_atomicity Snippet",
+	"body" : [ "MPI_File_get_atomicity( ${1:MPI_File fh}, ${2:int* flag});"]
+},
+
+"MPI_File_get_byte_offset": {
+	"prefix": ["MPI_File_get_byte_offset"],
+	"description" : "MPI File_get_byte_offset Snippet",
+	"body" : [ "MPI_File_get_byte_offset( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:MPI_Offset* disp});"]
+},
+
+"MPI_File_get_errhandler": {
+	"prefix": ["MPI_File_get_errhandler"],
+	"description" : "MPI File_get_errhandler Snippet",
+	"body" : [ "MPI_File_get_errhandler( ${1:MPI_File file}, ${2:MPI_Errhandler* errhandler});"]
+},
+
+"MPI_File_get_group": {
+	"prefix": ["MPI_File_get_group"],
+	"description" : "MPI File_get_group Snippet",
+	"body" : [ "MPI_File_get_group( ${1:MPI_File fh}, ${2:MPI_Group* group});"]
+},
+
+"MPI_File_get_info": {
+	"prefix": ["MPI_File_get_info"],
+	"description" : "MPI File_get_info Snippet",
+	"body" : [ "MPI_File_get_info( ${1:MPI_File fh}, ${2:MPI_Info* info_used});"]
+},
+
+"MPI_File_get_position": {
+	"prefix": ["MPI_File_get_position"],
+	"description" : "MPI File_get_position Snippet",
+	"body" : [ "MPI_File_get_position( ${1:MPI_File fh}, ${2:MPI_Offset* offset});"]
+},
+
+"MPI_File_get_position_shared": {
+	"prefix": ["MPI_File_get_position_shared"],
+	"description" : "MPI File_get_position_shared Snippet",
+	"body" : [ "MPI_File_get_position_shared( ${1:MPI_File fh}, ${2:MPI_Offset* offset});"]
+},
+
+"MPI_File_get_size": {
+	"prefix": ["MPI_File_get_size"],
+	"description" : "MPI File_get_size Snippet",
+	"body" : [ "MPI_File_get_size( ${1:MPI_File fh}, ${2:MPI_Offset* size});"]
+},
+
+"MPI_File_get_type_extent": {
+	"prefix": ["MPI_File_get_type_extent"],
+	"description" : "MPI File_get_type_extent Snippet",
+	"body" : [ "MPI_File_get_type_extent( ${1:MPI_File fh}, ${2:MPI_Datatype datatype}, ${3:MPI_Count* extent});"]
+},
+
+"MPI_File_get_view": {
+	"prefix": ["MPI_File_get_view"],
+	"description" : "MPI File_get_view Snippet",
+	"body" : [ "MPI_File_get_view( ${1:MPI_File fh}, ${2:MPI_Offset* disp}, ${3:MPI_Datatype* etype}, ${4:MPI_Datatype* filetype}, ${5:char* datarep});"]
+},
+
+"MPI_File_iread": {
+	"prefix": ["MPI_File_iread"],
+	"description" : "MPI File_iread Snippet",
+	"body" : [ "MPI_File_iread( ${1:MPI_File fh}, ${2:void* buf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Request* request});"]
+},
+
+"MPI_File_iread_all": {
+	"prefix": ["MPI_File_iread_all"],
+	"description" : "MPI File_iread_all Snippet",
+	"body" : [ "MPI_File_iread_all( ${1:MPI_File fh}, ${2:void* buf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Request* request});"]
+},
+
+"MPI_File_iread_at": {
+	"prefix": ["MPI_File_iread_at"],
+	"description" : "MPI File_iread_at Snippet",
+	"body" : [ "MPI_File_iread_at( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:void* buf}, ${4:MPI_Count count}, ${5:MPI_Datatype datatype}, ${6:MPI_Request* request});"]
+},
+
+"MPI_File_iread_at_all": {
+	"prefix": ["MPI_File_iread_at_all"],
+	"description" : "MPI File_iread_at_all Snippet",
+	"body" : [ "MPI_File_iread_at_all( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:void* buf}, ${4:MPI_Count count}, ${5:MPI_Datatype datatype}, ${6:MPI_Request* request});"]
+},
+
+"MPI_File_iread_shared": {
+	"prefix": ["MPI_File_iread_shared"],
+	"description" : "MPI File_iread_shared Snippet",
+	"body" : [ "MPI_File_iread_shared( ${1:MPI_File fh}, ${2:void* buf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Request* request});"]
+},
+
+"MPI_File_iwrite": {
+	"prefix": ["MPI_File_iwrite"],
+	"description" : "MPI File_iwrite Snippet",
+	"body" : [ "MPI_File_iwrite( ${1:MPI_File fh}, ${2:const void* buf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Request* request});"]
+},
+
+"MPI_File_iwrite_all": {
+	"prefix": ["MPI_File_iwrite_all"],
+	"description" : "MPI File_iwrite_all Snippet",
+	"body" : [ "MPI_File_iwrite_all( ${1:MPI_File fh}, ${2:const void* buf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Request* request});"]
+},
+
+"MPI_File_iwrite_at": {
+	"prefix": ["MPI_File_iwrite_at"],
+	"description" : "MPI File_iwrite_at Snippet",
+	"body" : [ "MPI_File_iwrite_at( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:const void* buf}, ${4:MPI_Count count}, ${5:MPI_Datatype datatype}, ${6:MPI_Request* request});"]
+},
+
+"MPI_File_iwrite_at_all": {
+	"prefix": ["MPI_File_iwrite_at_all"],
+	"description" : "MPI File_iwrite_at_all Snippet",
+	"body" : [ "MPI_File_iwrite_at_all( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:const void* buf}, ${4:MPI_Count count}, ${5:MPI_Datatype datatype}, ${6:MPI_Request* request});"]
+},
+
+"MPI_File_iwrite_shared": {
+	"prefix": ["MPI_File_iwrite_shared"],
+	"description" : "MPI File_iwrite_shared Snippet",
+	"body" : [ "MPI_File_iwrite_shared( ${1:MPI_File fh}, ${2:const void* buf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Request* request});"]
+},
+
+"MPI_File_open": {
+	"prefix": ["MPI_File_open"],
+	"description" : "MPI File_open Snippet",
+	"body" : [ "MPI_File_open( ${1:MPI_Comm comm}, ${2:const char* filename}, ${3:int amode}, ${4:MPI_Info info}, ${5:MPI_File* fh});"]
+},
+
+"MPI_File_preallocate": {
+	"prefix": ["MPI_File_preallocate"],
+	"description" : "MPI File_preallocate Snippet",
+	"body" : [ "MPI_File_preallocate( ${1:MPI_File fh}, ${2:MPI_Offset size});"]
+},
+
+"MPI_File_read": {
+	"prefix": ["MPI_File_read"],
+	"description" : "MPI File_read Snippet",
+	"body" : [ "MPI_File_read( ${1:MPI_File fh}, ${2:void* buf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Status* status});"]
+},
+
+"MPI_File_read_all": {
+	"prefix": ["MPI_File_read_all"],
+	"description" : "MPI File_read_all Snippet",
+	"body" : [ "MPI_File_read_all( ${1:MPI_File fh}, ${2:void* buf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Status* status});"]
+},
+
+"MPI_File_read_all_begin": {
+	"prefix": ["MPI_File_read_all_begin"],
+	"description" : "MPI File_read_all_begin Snippet",
+	"body" : [ "MPI_File_read_all_begin( ${1:MPI_File fh}, ${2:void* buf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype});"]
+},
+
+"MPI_File_read_all_end": {
+	"prefix": ["MPI_File_read_all_end"],
+	"description" : "MPI File_read_all_end Snippet",
+	"body" : [ "MPI_File_read_all_end( ${1:MPI_File fh}, ${2:void* buf}, ${3:MPI_Status* status});"]
+},
+
+"MPI_File_read_at": {
+	"prefix": ["MPI_File_read_at"],
+	"description" : "MPI File_read_at Snippet",
+	"body" : [ "MPI_File_read_at( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:void* buf}, ${4:MPI_Count count}, ${5:MPI_Datatype datatype}, ${6:MPI_Status* status});"]
+},
+
+"MPI_File_read_at_all": {
+	"prefix": ["MPI_File_read_at_all"],
+	"description" : "MPI File_read_at_all Snippet",
+	"body" : [ "MPI_File_read_at_all( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:void* buf}, ${4:MPI_Count count}, ${5:MPI_Datatype datatype}, ${6:MPI_Status* status});"]
+},
+
+"MPI_File_read_at_all_begin": {
+	"prefix": ["MPI_File_read_at_all_begin"],
+	"description" : "MPI File_read_at_all_begin Snippet",
+	"body" : [ "MPI_File_read_at_all_begin( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:void* buf}, ${4:MPI_Count count}, ${5:MPI_Datatype datatype});"]
+},
+
+"MPI_File_read_at_all_end": {
+	"prefix": ["MPI_File_read_at_all_end"],
+	"description" : "MPI File_read_at_all_end Snippet",
+	"body" : [ "MPI_File_read_at_all_end( ${1:MPI_File fh}, ${2:void* buf}, ${3:MPI_Status* status});"]
+},
+
+"MPI_File_read_ordered": {
+	"prefix": ["MPI_File_read_ordered"],
+	"description" : "MPI File_read_ordered Snippet",
+	"body" : [ "MPI_File_read_ordered( ${1:MPI_File fh}, ${2:void* buf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Status* status});"]
+},
+
+"MPI_File_read_ordered_begin": {
+	"prefix": ["MPI_File_read_ordered_begin"],
+	"description" : "MPI File_read_ordered_begin Snippet",
+	"body" : [ "MPI_File_read_ordered_begin( ${1:MPI_File fh}, ${2:void* buf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype});"]
+},
+
+"MPI_File_read_ordered_end": {
+	"prefix": ["MPI_File_read_ordered_end"],
+	"description" : "MPI File_read_ordered_end Snippet",
+	"body" : [ "MPI_File_read_ordered_end( ${1:MPI_File fh}, ${2:void* buf}, ${3:MPI_Status* status});"]
+},
+
+"MPI_File_read_shared": {
+	"prefix": ["MPI_File_read_shared"],
+	"description" : "MPI File_read_shared Snippet",
+	"body" : [ "MPI_File_read_shared( ${1:MPI_File fh}, ${2:void* buf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Status* status});"]
+},
+
+"MPI_File_seek": {
+	"prefix": ["MPI_File_seek"],
+	"description" : "MPI File_seek Snippet",
+	"body" : [ "MPI_File_seek( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:int whence});"]
+},
+
+"MPI_File_seek_shared": {
+	"prefix": ["MPI_File_seek_shared"],
+	"description" : "MPI File_seek_shared Snippet",
+	"body" : [ "MPI_File_seek_shared( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:int whence});"]
+},
+
+"MPI_File_set_atomicity": {
+	"prefix": ["MPI_File_set_atomicity"],
+	"description" : "MPI File_set_atomicity Snippet",
+	"body" : [ "MPI_File_set_atomicity( ${1:MPI_File fh}, ${2:int flag});"]
+},
+
+"MPI_File_set_errhandler": {
+	"prefix": ["MPI_File_set_errhandler"],
+	"description" : "MPI File_set_errhandler Snippet",
+	"body" : [ "MPI_File_set_errhandler( ${1:MPI_File file}, ${2:MPI_Errhandler errhandler});"]
+},
+
+"MPI_File_set_info": {
+	"prefix": ["MPI_File_set_info"],
+	"description" : "MPI File_set_info Snippet",
+	"body" : [ "MPI_File_set_info( ${1:MPI_File fh}, ${2:MPI_Info info});"]
+},
+
+"MPI_File_set_size": {
+	"prefix": ["MPI_File_set_size"],
+	"description" : "MPI File_set_size Snippet",
+	"body" : [ "MPI_File_set_size( ${1:MPI_File fh}, ${2:MPI_Offset size});"]
+},
+
+"MPI_File_set_view": {
+	"prefix": ["MPI_File_set_view"],
+	"description" : "MPI File_set_view Snippet",
+	"body" : [ "MPI_File_set_view( ${1:MPI_File fh}, ${2:MPI_Offset disp}, ${3:MPI_Datatype etype}, ${4:MPI_Datatype filetype}, ${5:const char* datarep}, ${6:MPI_Info info});"]
+},
+
+"MPI_File_sync": {
+	"prefix": ["MPI_File_sync"],
+	"description" : "MPI File_sync Snippet",
+	"body" : [ "MPI_File_sync( ${1:MPI_File fh});"]
+},
+
+"MPI_File_write": {
+	"prefix": ["MPI_File_write"],
+	"description" : "MPI File_write Snippet",
+	"body" : [ "MPI_File_write( ${1:MPI_File fh}, ${2:const void* buf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Status* status});"]
+},
+
+"MPI_File_write_all": {
+	"prefix": ["MPI_File_write_all"],
+	"description" : "MPI File_write_all Snippet",
+	"body" : [ "MPI_File_write_all( ${1:MPI_File fh}, ${2:const void* buf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Status* status});"]
+},
+
+"MPI_File_write_all_begin": {
+	"prefix": ["MPI_File_write_all_begin"],
+	"description" : "MPI File_write_all_begin Snippet",
+	"body" : [ "MPI_File_write_all_begin( ${1:MPI_File fh}, ${2:const void* buf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype});"]
+},
+
+"MPI_File_write_all_end": {
+	"prefix": ["MPI_File_write_all_end"],
+	"description" : "MPI File_write_all_end Snippet",
+	"body" : [ "MPI_File_write_all_end( ${1:MPI_File fh}, ${2:const void* buf}, ${3:MPI_Status* status});"]
+},
+
+"MPI_File_write_at": {
+	"prefix": ["MPI_File_write_at"],
+	"description" : "MPI File_write_at Snippet",
+	"body" : [ "MPI_File_write_at( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:const void* buf}, ${4:MPI_Count count}, ${5:MPI_Datatype datatype}, ${6:MPI_Status* status});"]
+},
+
+"MPI_File_write_at_all": {
+	"prefix": ["MPI_File_write_at_all"],
+	"description" : "MPI File_write_at_all Snippet",
+	"body" : [ "MPI_File_write_at_all( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:const void* buf}, ${4:MPI_Count count}, ${5:MPI_Datatype datatype}, ${6:MPI_Status* status});"]
+},
+
+"MPI_File_write_at_all_begin": {
+	"prefix": ["MPI_File_write_at_all_begin"],
+	"description" : "MPI File_write_at_all_begin Snippet",
+	"body" : [ "MPI_File_write_at_all_begin( ${1:MPI_File fh}, ${2:MPI_Offset offset}, ${3:const void* buf}, ${4:MPI_Count count}, ${5:MPI_Datatype datatype});"]
+},
+
+"MPI_File_write_at_all_end": {
+	"prefix": ["MPI_File_write_at_all_end"],
+	"description" : "MPI File_write_at_all_end Snippet",
+	"body" : [ "MPI_File_write_at_all_end( ${1:MPI_File fh}, ${2:const void* buf}, ${3:MPI_Status* status});"]
+},
+
+"MPI_File_write_ordered": {
+	"prefix": ["MPI_File_write_ordered"],
+	"description" : "MPI File_write_ordered Snippet",
+	"body" : [ "MPI_File_write_ordered( ${1:MPI_File fh}, ${2:const void* buf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Status* status});"]
+},
+
+"MPI_File_write_ordered_begin": {
+	"prefix": ["MPI_File_write_ordered_begin"],
+	"description" : "MPI File_write_ordered_begin Snippet",
+	"body" : [ "MPI_File_write_ordered_begin( ${1:MPI_File fh}, ${2:const void* buf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype});"]
+},
+
+"MPI_File_write_ordered_end": {
+	"prefix": ["MPI_File_write_ordered_end"],
+	"description" : "MPI File_write_ordered_end Snippet",
+	"body" : [ "MPI_File_write_ordered_end( ${1:MPI_File fh}, ${2:const void* buf}, ${3:MPI_Status* status});"]
+},
+
+"MPI_File_write_shared": {
+	"prefix": ["MPI_File_write_shared"],
+	"description" : "MPI File_write_shared Snippet",
+	"body" : [ "MPI_File_write_shared( ${1:MPI_File fh}, ${2:const void* buf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Status* status});"]
+},
+
+"MPI_Finalize": {
+	"prefix": ["MPI_Finalize"],
+	"description" : "MPI Finalize Snippet",
+	"body" : [ "MPI_Finalize();"]
+},
+
+"MPI_Finalized": {
+	"prefix": ["MPI_Finalized"],
+	"description" : "MPI Finalized Snippet",
+	"body" : [ "MPI_Finalized( ${1:int* flag});"]
+},
+
+"MPI_Free_mem": {
+	"prefix": ["MPI_Free_mem"],
+	"description" : "MPI Free_mem Snippet",
+	"body" : [ "MPI_Free_mem( ${1:void* base});"]
+},
+
+"MPI_Gather": {
+	"prefix": ["MPI_Gather"],
+	"description" : "MPI Gather Snippet",
+	"body" : [ "MPI_Gather( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:MPI_Count recvcount}, ${6:MPI_Datatype recvtype}, ${7:int root}, ${8:MPI_Comm comm});"]
+},
+
+"MPI_Gather_init": {
+	"prefix": ["MPI_Gather_init"],
+	"description" : "MPI Gather_init Snippet",
+	"body" : [ "MPI_Gather_init( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:MPI_Count recvcount}, ${6:MPI_Datatype recvtype}, ${7:int root}, ${8:MPI_Comm comm}, ${9:MPI_Info info}, ${10:MPI_Request* request});"]
+},
+
+"MPI_Gatherv": {
+	"prefix": ["MPI_Gatherv"],
+	"description" : "MPI Gatherv Snippet",
+	"body" : [ "MPI_Gatherv( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:const MPI_Count recvcounts[]}, ${6:const MPI_Aint displs[]}, ${7:MPI_Datatype recvtype}, ${8:int root}, ${9:MPI_Comm comm});"]
+},
+
+"MPI_Gatherv_init": {
+	"prefix": ["MPI_Gatherv_init"],
+	"description" : "MPI Gatherv_init Snippet",
+	"body" : [ "MPI_Gatherv_init( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:const MPI_Count recvcounts[]}, ${6:const MPI_Aint displs[]}, ${7:MPI_Datatype recvtype}, ${8:int root}, ${9:MPI_Comm comm}, ${10:MPI_Info info}, ${11:MPI_Request* request});"]
+},
+
+"MPI_Get": {
+	"prefix": ["MPI_Get"],
+	"description" : "MPI Get Snippet",
+	"body" : [ "MPI_Get( ${1:void* origin_addr}, ${2:MPI_Count origin_count}, ${3:MPI_Datatype origin_datatype}, ${4:int target_rank}, ${5:MPI_Aint target_disp}, ${6:MPI_Count target_count}, ${7:MPI_Datatype target_datatype}, ${8:MPI_Win win});"]
+},
+
+"MPI_Get_accumulate": {
+	"prefix": ["MPI_Get_accumulate"],
+	"description" : "MPI Get_accumulate Snippet",
+	"body" : [ "MPI_Get_accumulate( ${1:const void* origin_addr}, ${2:MPI_Count origin_count}, ${3:MPI_Datatype origin_datatype}, ${4:void* result_addr}, ${5:MPI_Count result_count}, ${6:MPI_Datatype result_datatype}, ${7:int target_rank}, ${8:MPI_Aint target_disp}, ${9:MPI_Count target_count}, ${10:MPI_Datatype target_datatype}, ${11:MPI_Op op}, ${12:MPI_Win win});"]
+},
+
+"MPI_Get_address": {
+	"prefix": ["MPI_Get_address"],
+	"description" : "MPI Get_address Snippet",
+	"body" : [ "MPI_Get_address( ${1:const void* location}, ${2:MPI_Aint* address});"]
+},
+
+"MPI_Get_count": {
+	"prefix": ["MPI_Get_count"],
+	"description" : "MPI Get_count Snippet",
+	"body" : [ "MPI_Get_count( ${1:const MPI_Status* status}, ${2:MPI_Datatype datatype}, ${3:MPI_Count* count});"]
+},
+
+"MPI_Get_elements": {
+	"prefix": ["MPI_Get_elements"],
+	"description" : "MPI Get_elements Snippet",
+	"body" : [ "MPI_Get_elements( ${1:const MPI_Status* status}, ${2:MPI_Datatype datatype}, ${3:MPI_Count* count});"]
+},
+
+"MPI_Get_elements_x": {
+	"prefix": ["MPI_Get_elements_x"],
+	"description" : "MPI Get_elements_x Snippet",
+	"body" : [ "MPI_Get_elements_x( ${1:const MPI_Status* status}, ${2:MPI_Datatype datatype}, ${3:MPI_Count* count});"]
+},
+
+"MPI_Get_library_version": {
+	"prefix": ["MPI_Get_library_version"],
+	"description" : "MPI Get_library_version Snippet",
+	"body" : [ "MPI_Get_library_version( ${1:char* version}, ${2:int* resultlen});"]
+},
+
+"MPI_Get_processor_name": {
+	"prefix": ["MPI_Get_processor_name"],
+	"description" : "MPI Get_processor_name Snippet",
+	"body" : [ "MPI_Get_processor_name( ${1:char* name}, ${2:int* resultlen});"]
+},
+
+"MPI_Get_version": {
+	"prefix": ["MPI_Get_version"],
+	"description" : "MPI Get_version Snippet",
+	"body" : [ "MPI_Get_version( ${1:int* version}, ${2:int* subversion});"]
+},
+
+"MPI_Graph_create": {
+	"prefix": ["MPI_Graph_create"],
+	"description" : "MPI Graph_create Snippet",
+	"body" : [ "MPI_Graph_create( ${1:MPI_Comm comm_old}, ${2:int nnodes}, ${3:const int index[]}, ${4:const int edges[]}, ${5:int reorder}, ${6:MPI_Comm* comm_graph});"]
+},
+
+"MPI_Graph_get": {
+	"prefix": ["MPI_Graph_get"],
+	"description" : "MPI Graph_get Snippet",
+	"body" : [ "MPI_Graph_get( ${1:MPI_Comm comm}, ${2:int maxindex}, ${3:int maxedges}, ${4:int index[]}, ${5:int edges[]});"]
+},
+
+"MPI_Graph_map": {
+	"prefix": ["MPI_Graph_map"],
+	"description" : "MPI Graph_map Snippet",
+	"body" : [ "MPI_Graph_map( ${1:MPI_Comm comm}, ${2:int nnodes}, ${3:const int index[]}, ${4:const int edges[]}, ${5:int* newrank});"]
+},
+
+"MPI_Graph_neighbors": {
+	"prefix": ["MPI_Graph_neighbors"],
+	"description" : "MPI Graph_neighbors Snippet",
+	"body" : [ "MPI_Graph_neighbors( ${1:MPI_Comm comm}, ${2:int rank}, ${3:int maxneighbors}, ${4:int neighbors[]});"]
+},
+
+"MPI_Graph_neighbors_count": {
+	"prefix": ["MPI_Graph_neighbors_count"],
+	"description" : "MPI Graph_neighbors_count Snippet",
+	"body" : [ "MPI_Graph_neighbors_count( ${1:MPI_Comm comm}, ${2:int rank}, ${3:int* nneighbors});"]
+},
+
+"MPI_Graphdims_get": {
+	"prefix": ["MPI_Graphdims_get"],
+	"description" : "MPI Graphdims_get Snippet",
+	"body" : [ "MPI_Graphdims_get( ${1:MPI_Comm comm}, ${2:int* nnodes}, ${3:int* nedges});"]
+},
+
+"MPI_Grequest_complete": {
+	"prefix": ["MPI_Grequest_complete"],
+	"description" : "MPI Grequest_complete Snippet",
+	"body" : [ "MPI_Grequest_complete( ${1:MPI_Request request});"]
+},
+
+"MPI_Grequest_start": {
+	"prefix": ["MPI_Grequest_start"],
+	"description" : "MPI Grequest_start Snippet",
+	"body" : [ "MPI_Grequest_start( ${1:MPI_Grequest_query_function* query_fn}, ${2:MPI_Grequest_free_function* free_fn}, ${3:MPI_Grequest_cancel_function* cancel_fn}, ${4:void* extra_state}, ${5:MPI_Request* request});"]
+},
+
+"MPI_Group_compare": {
+	"prefix": ["MPI_Group_compare"],
+	"description" : "MPI Group_compare Snippet",
+	"body" : [ "MPI_Group_compare( ${1:MPI_Group group1}, ${2:MPI_Group group2}, ${3:int* result});"]
+},
+
+"MPI_Group_difference": {
+	"prefix": ["MPI_Group_difference"],
+	"description" : "MPI Group_difference Snippet",
+	"body" : [ "MPI_Group_difference( ${1:MPI_Group group1}, ${2:MPI_Group group2}, ${3:MPI_Group* newgroup});"]
+},
+
+"MPI_Group_excl": {
+	"prefix": ["MPI_Group_excl"],
+	"description" : "MPI Group_excl Snippet",
+	"body" : [ "MPI_Group_excl( ${1:MPI_Group group}, ${2:int n}, ${3:const int ranks[]}, ${4:MPI_Group* newgroup});"]
+},
+
+"MPI_Group_free": {
+	"prefix": ["MPI_Group_free"],
+	"description" : "MPI Group_free Snippet",
+	"body" : [ "MPI_Group_free( ${1:MPI_Group* group});"]
+},
+
+"MPI_Group_from_session_pset": {
+	"prefix": ["MPI_Group_from_session_pset"],
+	"description" : "MPI Group_from_session_pset Snippet",
+	"body" : [ "MPI_Group_from_session_pset( ${1:MPI_Session session}, ${2:const char* pset_name}, ${3:MPI_Group* newgroup});"]
+},
+
+"MPI_Group_incl": {
+	"prefix": ["MPI_Group_incl"],
+	"description" : "MPI Group_incl Snippet",
+	"body" : [ "MPI_Group_incl( ${1:MPI_Group group}, ${2:int n}, ${3:const int ranks[]}, ${4:MPI_Group* newgroup});"]
+},
+
+"MPI_Group_intersection": {
+	"prefix": ["MPI_Group_intersection"],
+	"description" : "MPI Group_intersection Snippet",
+	"body" : [ "MPI_Group_intersection( ${1:MPI_Group group1}, ${2:MPI_Group group2}, ${3:MPI_Group* newgroup});"]
+},
+
+"MPI_Group_range_excl": {
+	"prefix": ["MPI_Group_range_excl"],
+	"description" : "MPI Group_range_excl Snippet",
+	"body" : [ "MPI_Group_range_excl( ${1:MPI_Group group}, ${2:int n}, ${3:int ranges[][3]}, ${4:MPI_Group* newgroup});"]
+},
+
+"MPI_Group_range_incl": {
+	"prefix": ["MPI_Group_range_incl"],
+	"description" : "MPI Group_range_incl Snippet",
+	"body" : [ "MPI_Group_range_incl( ${1:MPI_Group group}, ${2:int n}, ${3:int ranges[][3]}, ${4:MPI_Group* newgroup});"]
+},
+
+"MPI_Group_rank": {
+	"prefix": ["MPI_Group_rank"],
+	"description" : "MPI Group_rank Snippet",
+	"body" : [ "MPI_Group_rank( ${1:MPI_Group group}, ${2:int* rank});"]
+},
+
+"MPI_Group_size": {
+	"prefix": ["MPI_Group_size"],
+	"description" : "MPI Group_size Snippet",
+	"body" : [ "MPI_Group_size( ${1:MPI_Group group}, ${2:int* size});"]
+},
+
+"MPI_Group_translate_ranks": {
+	"prefix": ["MPI_Group_translate_ranks"],
+	"description" : "MPI Group_translate_ranks Snippet",
+	"body" : [ "MPI_Group_translate_ranks( ${1:MPI_Group group1}, ${2:int n}, ${3:const int ranks1[]}, ${4:MPI_Group group2}, ${5:int ranks2[]});"]
+},
+
+"MPI_Group_union": {
+	"prefix": ["MPI_Group_union"],
+	"description" : "MPI Group_union Snippet",
+	"body" : [ "MPI_Group_union( ${1:MPI_Group group1}, ${2:MPI_Group group2}, ${3:MPI_Group* newgroup});"]
+},
+
+"MPI_Iallgather": {
+	"prefix": ["MPI_Iallgather"],
+	"description" : "MPI Iallgather Snippet",
+	"body" : [ "MPI_Iallgather( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:MPI_Count recvcount}, ${6:MPI_Datatype recvtype}, ${7:MPI_Comm comm}, ${8:MPI_Request* request});"]
+},
+
+"MPI_Iallgatherv": {
+	"prefix": ["MPI_Iallgatherv"],
+	"description" : "MPI Iallgatherv Snippet",
+	"body" : [ "MPI_Iallgatherv( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:const MPI_Count recvcounts[]}, ${6:const MPI_Aint displs[]}, ${7:MPI_Datatype recvtype}, ${8:MPI_Comm comm}, ${9:MPI_Request* request});"]
+},
+
+"MPI_Iallreduce": {
+	"prefix": ["MPI_Iallreduce"],
+	"description" : "MPI Iallreduce Snippet",
+	"body" : [ "MPI_Iallreduce( ${1:const void* sendbuf}, ${2:void* recvbuf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
+},
+
+"MPI_Ialltoall": {
+	"prefix": ["MPI_Ialltoall"],
+	"description" : "MPI Ialltoall Snippet",
+	"body" : [ "MPI_Ialltoall( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:MPI_Count recvcount}, ${6:MPI_Datatype recvtype}, ${7:MPI_Comm comm}, ${8:MPI_Request* request});"]
+},
+
+"MPI_Ialltoallv": {
+	"prefix": ["MPI_Ialltoallv"],
+	"description" : "MPI Ialltoallv Snippet",
+	"body" : [ "MPI_Ialltoallv( ${1:const void* sendbuf}, ${2:const MPI_Count sendcounts[]}, ${3:const MPI_Aint sdispls[]}, ${4:MPI_Datatype sendtype}, ${5:void* recvbuf}, ${6:const MPI_Count recvcounts[]}, ${7:const MPI_Aint rdispls[]}, ${8:MPI_Datatype recvtype}, ${9:MPI_Comm comm}, ${10:MPI_Request* request});"]
+},
+
+"MPI_Ialltoallw": {
+	"prefix": ["MPI_Ialltoallw"],
+	"description" : "MPI Ialltoallw Snippet",
+	"body" : [ "MPI_Ialltoallw( ${1:const void* sendbuf}, ${2:const MPI_Count sendcounts[]}, ${3:const MPI_Aint sdispls[]}, ${4:const MPI_Datatype sendtypes[]}, ${5:void* recvbuf}, ${6:const MPI_Count recvcounts[]}, ${7:const MPI_Aint rdispls[]}, ${8:const MPI_Datatype recvtypes[]}, ${9:MPI_Comm comm}, ${10:MPI_Request* request});"]
+},
+
+"MPI_Ibarrier": {
+	"prefix": ["MPI_Ibarrier"],
+	"description" : "MPI Ibarrier Snippet",
+	"body" : [ "MPI_Ibarrier( ${1:MPI_Comm comm}, ${2:MPI_Request* request});"]
+},
+
+"MPI_Ibcast": {
+	"prefix": ["MPI_Ibcast"],
+	"description" : "MPI Ibcast Snippet",
+	"body" : [ "MPI_Ibcast( ${1:void* buffer}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int root}, ${5:MPI_Comm comm}, ${6:MPI_Request* request});"]
+},
+
+"MPI_Ibsend": {
+	"prefix": ["MPI_Ibsend"],
+	"description" : "MPI Ibsend Snippet",
+	"body" : [ "MPI_Ibsend( ${1:const void* buf}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
+},
+
+"MPI_Iexscan": {
+	"prefix": ["MPI_Iexscan"],
+	"description" : "MPI Iexscan Snippet",
+	"body" : [ "MPI_Iexscan( ${1:const void* sendbuf}, ${2:void* recvbuf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
+},
+
+"MPI_Igather": {
+	"prefix": ["MPI_Igather"],
+	"description" : "MPI Igather Snippet",
+	"body" : [ "MPI_Igather( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:MPI_Count recvcount}, ${6:MPI_Datatype recvtype}, ${7:int root}, ${8:MPI_Comm comm}, ${9:MPI_Request* request});"]
+},
+
+"MPI_Igatherv": {
+	"prefix": ["MPI_Igatherv"],
+	"description" : "MPI Igatherv Snippet",
+	"body" : [ "MPI_Igatherv( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:const MPI_Count recvcounts[]}, ${6:const MPI_Aint displs[]}, ${7:MPI_Datatype recvtype}, ${8:int root}, ${9:MPI_Comm comm}, ${10:MPI_Request* request});"]
+},
+
+"MPI_Improbe": {
+	"prefix": ["MPI_Improbe"],
+	"description" : "MPI Improbe Snippet",
+	"body" : [ "MPI_Improbe( ${1:int source}, ${2:int tag}, ${3:MPI_Comm comm}, ${4:int* flag}, ${5:MPI_Message* message}, ${6:MPI_Status* status});"]
+},
+
+"MPI_Imrecv": {
+	"prefix": ["MPI_Imrecv"],
+	"description" : "MPI Imrecv Snippet",
+	"body" : [ "MPI_Imrecv( ${1:void* buf}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:MPI_Message* message}, ${5:MPI_Request* request});"]
+},
+
+"MPI_Ineighbor_allgather": {
+	"prefix": ["MPI_Ineighbor_allgather"],
+	"description" : "MPI Ineighbor_allgather Snippet",
+	"body" : [ "MPI_Ineighbor_allgather( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:MPI_Count recvcount}, ${6:MPI_Datatype recvtype}, ${7:MPI_Comm comm}, ${8:MPI_Request* request});"]
+},
+
+"MPI_Ineighbor_allgatherv": {
+	"prefix": ["MPI_Ineighbor_allgatherv"],
+	"description" : "MPI Ineighbor_allgatherv Snippet",
+	"body" : [ "MPI_Ineighbor_allgatherv( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:const MPI_Count recvcounts[]}, ${6:const MPI_Aint displs[]}, ${7:MPI_Datatype recvtype}, ${8:MPI_Comm comm}, ${9:MPI_Request* request});"]
+},
+
+"MPI_Ineighbor_alltoall": {
+	"prefix": ["MPI_Ineighbor_alltoall"],
+	"description" : "MPI Ineighbor_alltoall Snippet",
+	"body" : [ "MPI_Ineighbor_alltoall( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:MPI_Count recvcount}, ${6:MPI_Datatype recvtype}, ${7:MPI_Comm comm}, ${8:MPI_Request* request});"]
+},
+
+"MPI_Ineighbor_alltoallv": {
+	"prefix": ["MPI_Ineighbor_alltoallv"],
+	"description" : "MPI Ineighbor_alltoallv Snippet",
+	"body" : [ "MPI_Ineighbor_alltoallv( ${1:const void* sendbuf}, ${2:const MPI_Count sendcounts[]}, ${3:const MPI_Aint sdispls[]}, ${4:MPI_Datatype sendtype}, ${5:void* recvbuf}, ${6:const MPI_Count recvcounts[]}, ${7:const MPI_Aint rdispls[]}, ${8:MPI_Datatype recvtype}, ${9:MPI_Comm comm}, ${10:MPI_Request* request});"]
+},
+
+"MPI_Ineighbor_alltoallw": {
+	"prefix": ["MPI_Ineighbor_alltoallw"],
+	"description" : "MPI Ineighbor_alltoallw Snippet",
+	"body" : [ "MPI_Ineighbor_alltoallw( ${1:const void* sendbuf}, ${2:const MPI_Count sendcounts[]}, ${3:const MPI_Aint sdispls[]}, ${4:const MPI_Datatype sendtypes[]}, ${5:void* recvbuf}, ${6:const MPI_Count recvcounts[]}, ${7:const MPI_Aint rdispls[]}, ${8:const MPI_Datatype recvtypes[]}, ${9:MPI_Comm comm}, ${10:MPI_Request* request});"]
+},
+
+"MPI_Info_create": {
+	"prefix": ["MPI_Info_create"],
+	"description" : "MPI Info_create Snippet",
+	"body" : [ "MPI_Info_create( ${1:MPI_Info* info});"]
+},
+
+"MPI_Info_create_env": {
+	"prefix": ["MPI_Info_create_env"],
+	"description" : "MPI Info_create_env Snippet",
+	"body" : [ "MPI_Info_create_env( ${1:int argc}, ${2:char argv[]}, ${3:MPI_Info* info});"]
+},
+
+"MPI_Info_delete": {
+	"prefix": ["MPI_Info_delete"],
+	"description" : "MPI Info_delete Snippet",
+	"body" : [ "MPI_Info_delete( ${1:MPI_Info info}, ${2:const char* key});"]
+},
+
+"MPI_Info_dup": {
+	"prefix": ["MPI_Info_dup"],
+	"description" : "MPI Info_dup Snippet",
+	"body" : [ "MPI_Info_dup( ${1:MPI_Info info}, ${2:MPI_Info* newinfo});"]
+},
+
+"MPI_Info_free": {
+	"prefix": ["MPI_Info_free"],
+	"description" : "MPI Info_free Snippet",
+	"body" : [ "MPI_Info_free( ${1:MPI_Info* info});"]
+},
+
+"MPI_Info_get": {
+	"prefix": ["MPI_Info_get"],
+	"description" : "MPI Info_get Snippet",
+	"body" : [ "MPI_Info_get( ${1:MPI_Info info}, ${2:const char* key}, ${3:int valuelen}, ${4:char* value}, ${5:int* flag});"]
+},
+
+"MPI_Info_get_nkeys": {
+	"prefix": ["MPI_Info_get_nkeys"],
+	"description" : "MPI Info_get_nkeys Snippet",
+	"body" : [ "MPI_Info_get_nkeys( ${1:MPI_Info info}, ${2:int* nkeys});"]
+},
+
+"MPI_Info_get_nthkey": {
+	"prefix": ["MPI_Info_get_nthkey"],
+	"description" : "MPI Info_get_nthkey Snippet",
+	"body" : [ "MPI_Info_get_nthkey( ${1:MPI_Info info}, ${2:int n}, ${3:char* key});"]
+},
+
+"MPI_Info_get_string": {
+	"prefix": ["MPI_Info_get_string"],
+	"description" : "MPI Info_get_string Snippet",
+	"body" : [ "MPI_Info_get_string( ${1:MPI_Info info}, ${2:const char* key}, ${3:int* buflen}, ${4:char* value}, ${5:int* flag});"]
+},
+
+"MPI_Info_get_valuelen": {
+	"prefix": ["MPI_Info_get_valuelen"],
+	"description" : "MPI Info_get_valuelen Snippet",
+	"body" : [ "MPI_Info_get_valuelen( ${1:MPI_Info info}, ${2:const char* key}, ${3:int* valuelen}, ${4:int* flag});"]
+},
+
+"MPI_Info_set": {
+	"prefix": ["MPI_Info_set"],
+	"description" : "MPI Info_set Snippet",
+	"body" : [ "MPI_Info_set( ${1:MPI_Info info}, ${2:const char* key}, ${3:const char* value});"]
+},
+
+"MPI_Init": {
+	"prefix": ["MPI_Init"],
+	"description" : "MPI Init Snippet",
+	"body" : [ "MPI_Init( ${1:int* argc}, ${2:char*** argv});"]
+},
+
+"MPI_Init_thread": {
+	"prefix": ["MPI_Init_thread"],
+	"description" : "MPI Init_thread Snippet",
+	"body" : [ "MPI_Init_thread( ${1:int* argc}, ${2:char*** argv}, ${3:int required}, ${4:int* provided});"]
+},
+
+"MPI_Initialized": {
+	"prefix": ["MPI_Initialized"],
+	"description" : "MPI Initialized Snippet",
+	"body" : [ "MPI_Initialized( ${1:int* flag});"]
+},
+
+"MPI_Intercomm_create": {
+	"prefix": ["MPI_Intercomm_create"],
+	"description" : "MPI Intercomm_create Snippet",
+	"body" : [ "MPI_Intercomm_create( ${1:MPI_Comm local_comm}, ${2:int local_leader}, ${3:MPI_Comm peer_comm}, ${4:int remote_leader}, ${5:int tag}, ${6:MPI_Comm* newintercomm});"]
+},
+
+"MPI_Intercomm_create_from_groups": {
+	"prefix": ["MPI_Intercomm_create_from_groups"],
+	"description" : "MPI Intercomm_create_from_groups Snippet",
+	"body" : [ "MPI_Intercomm_create_from_groups( ${1:MPI_Group local_group}, ${2:int local_leader}, ${3:MPI_Group remote_group}, ${4:int remote_leader}, ${5:const char* stringtag}, ${6:MPI_Info info}, ${7:MPI_Errhandler errhandler}, ${8:MPI_Comm* newintercomm});"]
+},
+
+"MPI_Intercomm_merge": {
+	"prefix": ["MPI_Intercomm_merge"],
+	"description" : "MPI Intercomm_merge Snippet",
+	"body" : [ "MPI_Intercomm_merge( ${1:MPI_Comm intercomm}, ${2:int high}, ${3:MPI_Comm* newintracomm});"]
+},
+
+"MPI_Iprobe": {
+	"prefix": ["MPI_Iprobe"],
+	"description" : "MPI Iprobe Snippet",
+	"body" : [ "MPI_Iprobe( ${1:int source}, ${2:int tag}, ${3:MPI_Comm comm}, ${4:int* flag}, ${5:MPI_Status* status});"]
+},
+
+"MPI_Irecv": {
+	"prefix": ["MPI_Irecv"],
+	"description" : "MPI Irecv Snippet",
+	"body" : [ "MPI_Irecv( ${1:void* buf}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int source}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
+},
+
+"MPI_Ireduce": {
+	"prefix": ["MPI_Ireduce"],
+	"description" : "MPI Ireduce Snippet",
+	"body" : [ "MPI_Ireduce( ${1:const void* sendbuf}, ${2:void* recvbuf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:int root}, ${7:MPI_Comm comm}, ${8:MPI_Request* request});"]
+},
+
+"MPI_Ireduce_scatter": {
+	"prefix": ["MPI_Ireduce_scatter"],
+	"description" : "MPI Ireduce_scatter Snippet",
+	"body" : [ "MPI_Ireduce_scatter( ${1:const void* sendbuf}, ${2:void* recvbuf}, ${3:const MPI_Count recvcounts[]}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
+},
+
+"MPI_Ireduce_scatter_block": {
+	"prefix": ["MPI_Ireduce_scatter_block"],
+	"description" : "MPI Ireduce_scatter_block Snippet",
+	"body" : [ "MPI_Ireduce_scatter_block( ${1:const void* sendbuf}, ${2:void* recvbuf}, ${3:MPI_Count recvcount}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
+},
+
+"MPI_Irsend": {
+	"prefix": ["MPI_Irsend"],
+	"description" : "MPI Irsend Snippet",
+	"body" : [ "MPI_Irsend( ${1:const void* buf}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
+},
+
+"MPI_Is_thread_main": {
+	"prefix": ["MPI_Is_thread_main"],
+	"description" : "MPI Is_thread_main Snippet",
+	"body" : [ "MPI_Is_thread_main( ${1:int* flag});"]
+},
+
+"MPI_Iscan": {
+	"prefix": ["MPI_Iscan"],
+	"description" : "MPI Iscan Snippet",
+	"body" : [ "MPI_Iscan( ${1:const void* sendbuf}, ${2:void* recvbuf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
+},
+
+"MPI_Iscatter": {
+	"prefix": ["MPI_Iscatter"],
+	"description" : "MPI Iscatter Snippet",
+	"body" : [ "MPI_Iscatter( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:MPI_Count recvcount}, ${6:MPI_Datatype recvtype}, ${7:int root}, ${8:MPI_Comm comm}, ${9:MPI_Request* request});"]
+},
+
+"MPI_Iscatterv": {
+	"prefix": ["MPI_Iscatterv"],
+	"description" : "MPI Iscatterv Snippet",
+	"body" : [ "MPI_Iscatterv( ${1:const void* sendbuf}, ${2:const MPI_Count sendcounts[]}, ${3:const MPI_Aint displs[]}, ${4:MPI_Datatype sendtype}, ${5:void* recvbuf}, ${6:MPI_Count recvcount}, ${7:MPI_Datatype recvtype}, ${8:int root}, ${9:MPI_Comm comm}, ${10:MPI_Request* request});"]
+},
+
+"MPI_Isend": {
+	"prefix": ["MPI_Isend"],
+	"description" : "MPI Isend Snippet",
+	"body" : [ "MPI_Isend( ${1:const void* buf}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
+},
+
+"MPI_Isendrecv": {
+	"prefix": ["MPI_Isendrecv"],
+	"description" : "MPI Isendrecv Snippet",
+	"body" : [ "MPI_Isendrecv( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:int dest}, ${5:int sendtag}, ${6:void* recvbuf}, ${7:MPI_Count recvcount}, ${8:MPI_Datatype recvtype}, ${9:int source}, ${10:int recvtag}, ${11:MPI_Comm comm}, ${12:MPI_Request* request});"]
+},
+
+"MPI_Isendrecv_replace": {
+	"prefix": ["MPI_Isendrecv_replace"],
+	"description" : "MPI Isendrecv_replace Snippet",
+	"body" : [ "MPI_Isendrecv_replace( ${1:void* buf}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int sendtag}, ${6:int source}, ${7:int recvtag}, ${8:MPI_Comm comm}, ${9:MPI_Request* request});"]
+},
+
+"MPI_Issend": {
+	"prefix": ["MPI_Issend"],
+	"description" : "MPI Issend Snippet",
+	"body" : [ "MPI_Issend( ${1:const void* buf}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
+},
+
+"MPI_Keyval_create": {
+	"prefix": ["MPI_Keyval_create"],
+	"description" : "MPI Keyval_create Snippet",
+	"body" : [ "MPI_Keyval_create( ${1:MPI_Copy_function* copy_fn}, ${2:MPI_Delete_function* delete_fn}, ${3:int* keyval}, ${4:void* extra_state});"]
+},
+
+"MPI_Keyval_free": {
+	"prefix": ["MPI_Keyval_free"],
+	"description" : "MPI Keyval_free Snippet",
+	"body" : [ "MPI_Keyval_free( ${1:int* keyval});"]
+},
+
+"MPI_Lookup_name": {
+	"prefix": ["MPI_Lookup_name"],
+	"description" : "MPI Lookup_name Snippet",
+	"body" : [ "MPI_Lookup_name( ${1:const char* service_name}, ${2:MPI_Info info}, ${3:char* port_name});"]
+},
+
+"MPI_Mprobe": {
+	"prefix": ["MPI_Mprobe"],
+	"description" : "MPI Mprobe Snippet",
+	"body" : [ "MPI_Mprobe( ${1:int source}, ${2:int tag}, ${3:MPI_Comm comm}, ${4:MPI_Message* message}, ${5:MPI_Status* status});"]
+},
+
+"MPI_Mrecv": {
+	"prefix": ["MPI_Mrecv"],
+	"description" : "MPI Mrecv Snippet",
+	"body" : [ "MPI_Mrecv( ${1:void* buf}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:MPI_Message* message}, ${5:MPI_Status* status});"]
+},
+
+"MPI_Neighbor_allgather": {
+	"prefix": ["MPI_Neighbor_allgather"],
+	"description" : "MPI Neighbor_allgather Snippet",
+	"body" : [ "MPI_Neighbor_allgather( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:MPI_Count recvcount}, ${6:MPI_Datatype recvtype}, ${7:MPI_Comm comm});"]
+},
+
+"MPI_Neighbor_allgather_init": {
+	"prefix": ["MPI_Neighbor_allgather_init"],
+	"description" : "MPI Neighbor_allgather_init Snippet",
+	"body" : [ "MPI_Neighbor_allgather_init( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:MPI_Count recvcount}, ${6:MPI_Datatype recvtype}, ${7:MPI_Comm comm}, ${8:MPI_Info info}, ${9:MPI_Request* request});"]
+},
+
+"MPI_Neighbor_allgatherv": {
+	"prefix": ["MPI_Neighbor_allgatherv"],
+	"description" : "MPI Neighbor_allgatherv Snippet",
+	"body" : [ "MPI_Neighbor_allgatherv( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:const MPI_Count recvcounts[]}, ${6:const MPI_Aint displs[]}, ${7:MPI_Datatype recvtype}, ${8:MPI_Comm comm});"]
+},
+
+"MPI_Neighbor_allgatherv_init": {
+	"prefix": ["MPI_Neighbor_allgatherv_init"],
+	"description" : "MPI Neighbor_allgatherv_init Snippet",
+	"body" : [ "MPI_Neighbor_allgatherv_init( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:const MPI_Count recvcounts[]}, ${6:const MPI_Aint displs[]}, ${7:MPI_Datatype recvtype}, ${8:MPI_Comm comm}, ${9:MPI_Info info}, ${10:MPI_Request* request});"]
+},
+
+"MPI_Neighbor_alltoall": {
+	"prefix": ["MPI_Neighbor_alltoall"],
+	"description" : "MPI Neighbor_alltoall Snippet",
+	"body" : [ "MPI_Neighbor_alltoall( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:MPI_Count recvcount}, ${6:MPI_Datatype recvtype}, ${7:MPI_Comm comm});"]
+},
+
+"MPI_Neighbor_alltoall_init": {
+	"prefix": ["MPI_Neighbor_alltoall_init"],
+	"description" : "MPI Neighbor_alltoall_init Snippet",
+	"body" : [ "MPI_Neighbor_alltoall_init( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:MPI_Count recvcount}, ${6:MPI_Datatype recvtype}, ${7:MPI_Comm comm}, ${8:MPI_Info info}, ${9:MPI_Request* request});"]
+},
+
+"MPI_Neighbor_alltoallv": {
+	"prefix": ["MPI_Neighbor_alltoallv"],
+	"description" : "MPI Neighbor_alltoallv Snippet",
+	"body" : [ "MPI_Neighbor_alltoallv( ${1:const void* sendbuf}, ${2:const MPI_Count sendcounts[]}, ${3:const MPI_Aint sdispls[]}, ${4:MPI_Datatype sendtype}, ${5:void* recvbuf}, ${6:const MPI_Count recvcounts[]}, ${7:const MPI_Aint rdispls[]}, ${8:MPI_Datatype recvtype}, ${9:MPI_Comm comm});"]
+},
+
+"MPI_Neighbor_alltoallv_init": {
+	"prefix": ["MPI_Neighbor_alltoallv_init"],
+	"description" : "MPI Neighbor_alltoallv_init Snippet",
+	"body" : [ "MPI_Neighbor_alltoallv_init( ${1:const void* sendbuf}, ${2:const MPI_Count sendcounts[]}, ${3:const MPI_Aint sdispls[]}, ${4:MPI_Datatype sendtype}, ${5:void* recvbuf}, ${6:const MPI_Count recvcounts[]}, ${7:const MPI_Aint rdispls[]}, ${8:MPI_Datatype recvtype}, ${9:MPI_Comm comm}, ${10:MPI_Info info}, ${11:MPI_Request* request});"]
+},
+
+"MPI_Neighbor_alltoallw": {
+	"prefix": ["MPI_Neighbor_alltoallw"],
+	"description" : "MPI Neighbor_alltoallw Snippet",
+	"body" : [ "MPI_Neighbor_alltoallw( ${1:const void* sendbuf}, ${2:const MPI_Count sendcounts[]}, ${3:const MPI_Aint sdispls[]}, ${4:const MPI_Datatype sendtypes[]}, ${5:void* recvbuf}, ${6:const MPI_Count recvcounts[]}, ${7:const MPI_Aint rdispls[]}, ${8:const MPI_Datatype recvtypes[]}, ${9:MPI_Comm comm});"]
+},
+
+"MPI_Neighbor_alltoallw_init": {
+	"prefix": ["MPI_Neighbor_alltoallw_init"],
+	"description" : "MPI Neighbor_alltoallw_init Snippet",
+	"body" : [ "MPI_Neighbor_alltoallw_init( ${1:const void* sendbuf}, ${2:const MPI_Count sendcounts[]}, ${3:const MPI_Aint sdispls[]}, ${4:const MPI_Datatype sendtypes[]}, ${5:void* recvbuf}, ${6:const MPI_Count recvcounts[]}, ${7:const MPI_Aint rdispls[]}, ${8:const MPI_Datatype recvtypes[]}, ${9:MPI_Comm comm}, ${10:MPI_Info info}, ${11:MPI_Request* request});"]
+},
+
+"MPI_Op_commutative": {
+	"prefix": ["MPI_Op_commutative"],
+	"description" : "MPI Op_commutative Snippet",
+	"body" : [ "MPI_Op_commutative( ${1:MPI_Op op}, ${2:int* commute});"]
+},
+
+"MPI_Op_create": {
+	"prefix": ["MPI_Op_create"],
+	"description" : "MPI Op_create Snippet",
+	"body" : [ "MPI_Op_create( ${1:MPI_User_function* user_fn}, ${2:int commute}, ${3:MPI_Op* op});"]
+},
+
+"MPI_Op_free": {
+	"prefix": ["MPI_Op_free"],
+	"description" : "MPI Op_free Snippet",
+	"body" : [ "MPI_Op_free( ${1:MPI_Op* op});"]
+},
+
+"MPI_Open_port": {
+	"prefix": ["MPI_Open_port"],
+	"description" : "MPI Open_port Snippet",
+	"body" : [ "MPI_Open_port( ${1:MPI_Info info}, ${2:char* port_name});"]
+},
+
+"MPI_Pack": {
+	"prefix": ["MPI_Pack"],
+	"description" : "MPI Pack Snippet",
+	"body" : [ "MPI_Pack( ${1:const void* inbuf}, ${2:MPI_Count incount}, ${3:MPI_Datatype datatype}, ${4:void* outbuf}, ${5:MPI_Count outsize}, ${6:MPI_Count* position}, ${7:MPI_Comm comm});"]
+},
+
+"MPI_Pack_external": {
+	"prefix": ["MPI_Pack_external"],
+	"description" : "MPI Pack_external Snippet",
+	"body" : [ "MPI_Pack_external( ${1:const char datarep[]}, ${2:const void* inbuf}, ${3:MPI_Count incount}, ${4:MPI_Datatype datatype}, ${5:void* outbuf}, ${6:MPI_Count outsize}, ${7:MPI_Count* position});"]
+},
+
+"MPI_Pack_external_size": {
+	"prefix": ["MPI_Pack_external_size"],
+	"description" : "MPI Pack_external_size Snippet",
+	"body" : [ "MPI_Pack_external_size( ${1:const char datarep[]}, ${2:MPI_Count incount}, ${3:MPI_Datatype datatype}, ${4:MPI_Count* size});"]
+},
+
+"MPI_Pack_size": {
+	"prefix": ["MPI_Pack_size"],
+	"description" : "MPI Pack_size Snippet",
+	"body" : [ "MPI_Pack_size( ${1:MPI_Count incount}, ${2:MPI_Datatype datatype}, ${3:MPI_Comm comm}, ${4:MPI_Count* size});"]
+},
+
+"MPI_Parrived": {
+	"prefix": ["MPI_Parrived"],
+	"description" : "MPI Parrived Snippet",
+	"body" : [ "MPI_Parrived( ${1:MPI_Request request}, ${2:int partition}, ${3:int* flag});"]
+},
+
+"MPI_Pcontrol": {
+	"prefix": ["MPI_Pcontrol"],
+	"description" : "MPI Pcontrol Snippet",
+	"body" : [ "MPI_Pcontrol( ${1:const int level}, ${2:... });"]
+},
+
+"MPI_Pready": {
+	"prefix": ["MPI_Pready"],
+	"description" : "MPI Pready Snippet",
+	"body" : [ "MPI_Pready( ${1:int partition}, ${2:MPI_Request request});"]
+},
+
+"MPI_Pready_list": {
+	"prefix": ["MPI_Pready_list"],
+	"description" : "MPI Pready_list Snippet",
+	"body" : [ "MPI_Pready_list( ${1:int length}, ${2:const int array_of_partitions[]}, ${3:MPI_Request request});"]
+},
+
+"MPI_Pready_range": {
+	"prefix": ["MPI_Pready_range"],
+	"description" : "MPI Pready_range Snippet",
+	"body" : [ "MPI_Pready_range( ${1:int partition_low}, ${2:int partition_high}, ${3:MPI_Request request});"]
+},
+
+"MPI_Precv_init": {
+	"prefix": ["MPI_Precv_init"],
+	"description" : "MPI Precv_init Snippet",
+	"body" : [ "MPI_Precv_init( ${1:void* buf}, ${2:int partitions}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:int source}, ${6:int tag}, ${7:MPI_Comm comm}, ${8:MPI_Info info}, ${9:MPI_Request* request});"]
+},
+
+"MPI_Probe": {
+	"prefix": ["MPI_Probe"],
+	"description" : "MPI Probe Snippet",
+	"body" : [ "MPI_Probe( ${1:int source}, ${2:int tag}, ${3:MPI_Comm comm}, ${4:MPI_Status* status});"]
+},
+
+"MPI_Psend_init": {
+	"prefix": ["MPI_Psend_init"],
+	"description" : "MPI Psend_init Snippet",
+	"body" : [ "MPI_Psend_init( ${1:const void* buf}, ${2:int partitions}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:int dest}, ${6:int tag}, ${7:MPI_Comm comm}, ${8:MPI_Info info}, ${9:MPI_Request* request});"]
+},
+
+"MPI_Publish_name": {
+	"prefix": ["MPI_Publish_name"],
+	"description" : "MPI Publish_name Snippet",
+	"body" : [ "MPI_Publish_name( ${1:const char* service_name}, ${2:MPI_Info info}, ${3:const char* port_name});"]
+},
+
+"MPI_Put": {
+	"prefix": ["MPI_Put"],
+	"description" : "MPI Put Snippet",
+	"body" : [ "MPI_Put( ${1:const void* origin_addr}, ${2:MPI_Count origin_count}, ${3:MPI_Datatype origin_datatype}, ${4:int target_rank}, ${5:MPI_Aint target_disp}, ${6:MPI_Count target_count}, ${7:MPI_Datatype target_datatype}, ${8:MPI_Win win});"]
+},
+
+"MPI_Query_thread": {
+	"prefix": ["MPI_Query_thread"],
+	"description" : "MPI Query_thread Snippet",
+	"body" : [ "MPI_Query_thread( ${1:int* provided});"]
+},
+
+"MPI_Raccumulate": {
+	"prefix": ["MPI_Raccumulate"],
+	"description" : "MPI Raccumulate Snippet",
+	"body" : [ "MPI_Raccumulate( ${1:const void* origin_addr}, ${2:MPI_Count origin_count}, ${3:MPI_Datatype origin_datatype}, ${4:int target_rank}, ${5:MPI_Aint target_disp}, ${6:MPI_Count target_count}, ${7:MPI_Datatype target_datatype}, ${8:MPI_Op op}, ${9:MPI_Win win}, ${10:MPI_Request* request});"]
+},
+
+"MPI_Recv": {
+	"prefix": ["MPI_Recv"],
+	"description" : "MPI Recv Snippet",
+	"body" : [ "MPI_Recv( ${1:void* buf}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int source}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Status* status});"]
+},
+
+"MPI_Recv_init": {
+	"prefix": ["MPI_Recv_init"],
+	"description" : "MPI Recv_init Snippet",
+	"body" : [ "MPI_Recv_init( ${1:void* buf}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int source}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
+},
+
+"MPI_Reduce": {
+	"prefix": ["MPI_Reduce"],
+	"description" : "MPI Reduce Snippet",
+	"body" : [ "MPI_Reduce( ${1:const void* sendbuf}, ${2:void* recvbuf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:int root}, ${7:MPI_Comm comm});"]
+},
+
+"MPI_Reduce_init": {
+	"prefix": ["MPI_Reduce_init"],
+	"description" : "MPI Reduce_init Snippet",
+	"body" : [ "MPI_Reduce_init( ${1:const void* sendbuf}, ${2:void* recvbuf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:int root}, ${7:MPI_Comm comm}, ${8:MPI_Info info}, ${9:MPI_Request* request});"]
+},
+
+"MPI_Reduce_local": {
+	"prefix": ["MPI_Reduce_local"],
+	"description" : "MPI Reduce_local Snippet",
+	"body" : [ "MPI_Reduce_local( ${1:const void* inbuf}, ${2:void* inoutbuf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op});"]
+},
+
+"MPI_Reduce_scatter": {
+	"prefix": ["MPI_Reduce_scatter"],
+	"description" : "MPI Reduce_scatter Snippet",
+	"body" : [ "MPI_Reduce_scatter( ${1:const void* sendbuf}, ${2:void* recvbuf}, ${3:const MPI_Count recvcounts[]}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:MPI_Comm comm});"]
+},
+
+"MPI_Reduce_scatter_block": {
+	"prefix": ["MPI_Reduce_scatter_block"],
+	"description" : "MPI Reduce_scatter_block Snippet",
+	"body" : [ "MPI_Reduce_scatter_block( ${1:const void* sendbuf}, ${2:void* recvbuf}, ${3:MPI_Count recvcount}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:MPI_Comm comm});"]
+},
+
+"MPI_Reduce_scatter_block_init": {
+	"prefix": ["MPI_Reduce_scatter_block_init"],
+	"description" : "MPI Reduce_scatter_block_init Snippet",
+	"body" : [ "MPI_Reduce_scatter_block_init( ${1:const void* sendbuf}, ${2:void* recvbuf}, ${3:MPI_Count recvcount}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:MPI_Comm comm}, ${7:MPI_Info info}, ${8:MPI_Request* request});"]
+},
+
+"MPI_Reduce_scatter_init": {
+	"prefix": ["MPI_Reduce_scatter_init"],
+	"description" : "MPI Reduce_scatter_init Snippet",
+	"body" : [ "MPI_Reduce_scatter_init( ${1:const void* sendbuf}, ${2:void* recvbuf}, ${3:const MPI_Count recvcounts[]}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:MPI_Comm comm}, ${7:MPI_Info info}, ${8:MPI_Request* request});"]
+},
+
+"MPI_Register_datarep": {
+	"prefix": ["MPI_Register_datarep"],
+	"description" : "MPI Register_datarep Snippet",
+	"body" : [ "MPI_Register_datarep( ${1:const char* datarep}, ${2:MPI_Datarep_conversion_function* read_conversion_fn}, ${3:MPI_Datarep_conversion_function* write_conversion_fn}, ${4:MPI_Datarep_extent_function* dtype_file_extent_fn}, ${5:void* extra_state});"]
+},
+
+"MPI_Request_free": {
+	"prefix": ["MPI_Request_free"],
+	"description" : "MPI Request_free Snippet",
+	"body" : [ "MPI_Request_free( ${1:MPI_Request* request});"]
+},
+
+"MPI_Request_get_status": {
+	"prefix": ["MPI_Request_get_status"],
+	"description" : "MPI Request_get_status Snippet",
+	"body" : [ "MPI_Request_get_status( ${1:MPI_Request request}, ${2:int* flag}, ${3:MPI_Status* status});"]
+},
+
+"MPI_Rget": {
+	"prefix": ["MPI_Rget"],
+	"description" : "MPI Rget Snippet",
+	"body" : [ "MPI_Rget( ${1:void* origin_addr}, ${2:MPI_Count origin_count}, ${3:MPI_Datatype origin_datatype}, ${4:int target_rank}, ${5:MPI_Aint target_disp}, ${6:MPI_Count target_count}, ${7:MPI_Datatype target_datatype}, ${8:MPI_Win win}, ${9:MPI_Request* request});"]
+},
+
+"MPI_Rget_accumulate": {
+	"prefix": ["MPI_Rget_accumulate"],
+	"description" : "MPI Rget_accumulate Snippet",
+	"body" : [ "MPI_Rget_accumulate( ${1:const void* origin_addr}, ${2:MPI_Count origin_count}, ${3:MPI_Datatype origin_datatype}, ${4:void* result_addr}, ${5:MPI_Count result_count}, ${6:MPI_Datatype result_datatype}, ${7:int target_rank}, ${8:MPI_Aint target_disp}, ${9:MPI_Count target_count}, ${10:MPI_Datatype target_datatype}, ${11:MPI_Op op}, ${12:MPI_Win win}, ${13:MPI_Request* request});"]
+},
+
+"MPI_Rput": {
+	"prefix": ["MPI_Rput"],
+	"description" : "MPI Rput Snippet",
+	"body" : [ "MPI_Rput( ${1:const void* origin_addr}, ${2:MPI_Count origin_count}, ${3:MPI_Datatype origin_datatype}, ${4:int target_rank}, ${5:MPI_Aint target_disp}, ${6:MPI_Count target_count}, ${7:MPI_Datatype target_datatype}, ${8:MPI_Win win}, ${9:MPI_Request* request});"]
+},
+
+"MPI_Rsend": {
+	"prefix": ["MPI_Rsend"],
+	"description" : "MPI Rsend Snippet",
+	"body" : [ "MPI_Rsend( ${1:const void* buf}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm});"]
+},
+
+"MPI_Rsend_init": {
+	"prefix": ["MPI_Rsend_init"],
+	"description" : "MPI Rsend_init Snippet",
+	"body" : [ "MPI_Rsend_init( ${1:const void* buf}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
+},
+
+"MPI_Scan": {
+	"prefix": ["MPI_Scan"],
+	"description" : "MPI Scan Snippet",
+	"body" : [ "MPI_Scan( ${1:const void* sendbuf}, ${2:void* recvbuf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:MPI_Comm comm});"]
+},
+
+"MPI_Scan_init": {
+	"prefix": ["MPI_Scan_init"],
+	"description" : "MPI Scan_init Snippet",
+	"body" : [ "MPI_Scan_init( ${1:const void* sendbuf}, ${2:void* recvbuf}, ${3:MPI_Count count}, ${4:MPI_Datatype datatype}, ${5:MPI_Op op}, ${6:MPI_Comm comm}, ${7:MPI_Info info}, ${8:MPI_Request* request});"]
+},
+
+"MPI_Scatter": {
+	"prefix": ["MPI_Scatter"],
+	"description" : "MPI Scatter Snippet",
+	"body" : [ "MPI_Scatter( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:MPI_Count recvcount}, ${6:MPI_Datatype recvtype}, ${7:int root}, ${8:MPI_Comm comm});"]
+},
+
+"MPI_Scatter_init": {
+	"prefix": ["MPI_Scatter_init"],
+	"description" : "MPI Scatter_init Snippet",
+	"body" : [ "MPI_Scatter_init( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:void* recvbuf}, ${5:MPI_Count recvcount}, ${6:MPI_Datatype recvtype}, ${7:int root}, ${8:MPI_Comm comm}, ${9:MPI_Info info}, ${10:MPI_Request* request});"]
+},
+
+"MPI_Scatterv": {
+	"prefix": ["MPI_Scatterv"],
+	"description" : "MPI Scatterv Snippet",
+	"body" : [ "MPI_Scatterv( ${1:const void* sendbuf}, ${2:const MPI_Count sendcounts[]}, ${3:const MPI_Aint displs[]}, ${4:MPI_Datatype sendtype}, ${5:void* recvbuf}, ${6:MPI_Count recvcount}, ${7:MPI_Datatype recvtype}, ${8:int root}, ${9:MPI_Comm comm});"]
+},
+
+"MPI_Scatterv_init": {
+	"prefix": ["MPI_Scatterv_init"],
+	"description" : "MPI Scatterv_init Snippet",
+	"body" : [ "MPI_Scatterv_init( ${1:const void* sendbuf}, ${2:const MPI_Count sendcounts[]}, ${3:const MPI_Aint displs[]}, ${4:MPI_Datatype sendtype}, ${5:void* recvbuf}, ${6:MPI_Count recvcount}, ${7:MPI_Datatype recvtype}, ${8:int root}, ${9:MPI_Comm comm}, ${10:MPI_Info info}, ${11:MPI_Request* request});"]
+},
+
+"MPI_Send": {
+	"prefix": ["MPI_Send"],
+	"description" : "MPI Send Snippet",
+	"body" : [ "MPI_Send( ${1:const void* buf}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm});"]
+},
+
+"MPI_Send_init": {
+	"prefix": ["MPI_Send_init"],
+	"description" : "MPI Send_init Snippet",
+	"body" : [ "MPI_Send_init( ${1:const void* buf}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
+},
+
+"MPI_Sendrecv": {
+	"prefix": ["MPI_Sendrecv"],
+	"description" : "MPI Sendrecv Snippet",
+	"body" : [ "MPI_Sendrecv( ${1:const void* sendbuf}, ${2:MPI_Count sendcount}, ${3:MPI_Datatype sendtype}, ${4:int dest}, ${5:int sendtag}, ${6:void* recvbuf}, ${7:MPI_Count recvcount}, ${8:MPI_Datatype recvtype}, ${9:int source}, ${10:int recvtag}, ${11:MPI_Comm comm}, ${12:MPI_Status* status});"]
+},
+
+"MPI_Sendrecv_replace": {
+	"prefix": ["MPI_Sendrecv_replace"],
+	"description" : "MPI Sendrecv_replace Snippet",
+	"body" : [ "MPI_Sendrecv_replace( ${1:void* buf}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int sendtag}, ${6:int source}, ${7:int recvtag}, ${8:MPI_Comm comm}, ${9:MPI_Status* status});"]
+},
+
+"MPI_Session_call_errhandler": {
+	"prefix": ["MPI_Session_call_errhandler"],
+	"description" : "MPI Session_call_errhandler Snippet",
+	"body" : [ "MPI_Session_call_errhandler( ${1:MPI_Session session}, ${2:int errorcode});"]
+},
+
+"MPI_Session_create_errhandler": {
+	"prefix": ["MPI_Session_create_errhandler"],
+	"description" : "MPI Session_create_errhandler Snippet",
+	"body" : [ "MPI_Session_create_errhandler( ${1:MPI_Session_errhandler_function* session_errhandler_fn}, ${2:MPI_Errhandler* errhandler});"]
+},
+
+"MPI_Session_finalize": {
+	"prefix": ["MPI_Session_finalize"],
+	"description" : "MPI Session_finalize Snippet",
+	"body" : [ "MPI_Session_finalize( ${1:MPI_Session* session});"]
+},
+
+"MPI_Session_get_errhandler": {
+	"prefix": ["MPI_Session_get_errhandler"],
+	"description" : "MPI Session_get_errhandler Snippet",
+	"body" : [ "MPI_Session_get_errhandler( ${1:MPI_Session session}, ${2:MPI_Errhandler* errhandler});"]
+},
+
+"MPI_Session_get_info": {
+	"prefix": ["MPI_Session_get_info"],
+	"description" : "MPI Session_get_info Snippet",
+	"body" : [ "MPI_Session_get_info( ${1:MPI_Session session}, ${2:MPI_Info* info_used});"]
+},
+
+"MPI_Session_get_nth_pset": {
+	"prefix": ["MPI_Session_get_nth_pset"],
+	"description" : "MPI Session_get_nth_pset Snippet",
+	"body" : [ "MPI_Session_get_nth_pset( ${1:MPI_Session session}, ${2:MPI_Info info}, ${3:int n}, ${4:int* pset_len}, ${5:char* pset_name});"]
+},
+
+"MPI_Session_get_num_psets": {
+	"prefix": ["MPI_Session_get_num_psets"],
+	"description" : "MPI Session_get_num_psets Snippet",
+	"body" : [ "MPI_Session_get_num_psets( ${1:MPI_Session session}, ${2:MPI_Info info}, ${3:int* npset_names});"]
+},
+
+"MPI_Session_get_pset_info": {
+	"prefix": ["MPI_Session_get_pset_info"],
+	"description" : "MPI Session_get_pset_info Snippet",
+	"body" : [ "MPI_Session_get_pset_info( ${1:MPI_Session session}, ${2:const char* pset_name}, ${3:MPI_Info* info});"]
+},
+
+"MPI_Session_init": {
+	"prefix": ["MPI_Session_init"],
+	"description" : "MPI Session_init Snippet",
+	"body" : [ "MPI_Session_init( ${1:MPI_Info info}, ${2:MPI_Errhandler errhandler}, ${3:MPI_Session* session});"]
+},
+
+"MPI_Session_set_errhandler": {
+	"prefix": ["MPI_Session_set_errhandler"],
+	"description" : "MPI Session_set_errhandler Snippet",
+	"body" : [ "MPI_Session_set_errhandler( ${1:MPI_Session session}, ${2:MPI_Errhandler errhandler});"]
+},
+
+"MPI_Ssend": {
+	"prefix": ["MPI_Ssend"],
+	"description" : "MPI Ssend Snippet",
+	"body" : [ "MPI_Ssend( ${1:const void* buf}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm});"]
+},
+
+"MPI_Ssend_init": {
+	"prefix": ["MPI_Ssend_init"],
+	"description" : "MPI Ssend_init Snippet",
+	"body" : [ "MPI_Ssend_init( ${1:const void* buf}, ${2:MPI_Count count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm}, ${7:MPI_Request* request});"]
+},
+
+"MPI_Start": {
+	"prefix": ["MPI_Start"],
+	"description" : "MPI Start Snippet",
+	"body" : [ "MPI_Start( ${1:MPI_Request* request});"]
+},
+
+"MPI_Startall": {
+	"prefix": ["MPI_Startall"],
+	"description" : "MPI Startall Snippet",
+	"body" : [ "MPI_Startall( ${1:int count}, ${2:MPI_Request array_of_requests[]});"]
+},
+
+"MPI_Status_set_cancelled": {
+	"prefix": ["MPI_Status_set_cancelled"],
+	"description" : "MPI Status_set_cancelled Snippet",
+	"body" : [ "MPI_Status_set_cancelled( ${1:MPI_Status* status}, ${2:int flag});"]
+},
+
+"MPI_Status_set_elements": {
+	"prefix": ["MPI_Status_set_elements"],
+	"description" : "MPI Status_set_elements Snippet",
+	"body" : [ "MPI_Status_set_elements( ${1:MPI_Status* status}, ${2:MPI_Datatype datatype}, ${3:MPI_Count count});"]
+},
+
+"MPI_Status_set_elements_x": {
+	"prefix": ["MPI_Status_set_elements_x"],
+	"description" : "MPI Status_set_elements_x Snippet",
+	"body" : [ "MPI_Status_set_elements_x( ${1:MPI_Status* status}, ${2:MPI_Datatype datatype}, ${3:MPI_Count count});"]
+},
+
+"MPI_T_category_changed": {
+	"prefix": ["MPI_T_category_changed"],
+	"description" : "MPI T_category_changed Snippet",
+	"body" : [ "MPI_T_category_changed( ${1:int* update_number});"]
+},
+
+"MPI_T_category_get_categories": {
+	"prefix": ["MPI_T_category_get_categories"],
+	"description" : "MPI T_category_get_categories Snippet",
+	"body" : [ "MPI_T_category_get_categories( ${1:int cat_index}, ${2:int len}, ${3:int indices[]});"]
+},
+
+"MPI_T_category_get_cvars": {
+	"prefix": ["MPI_T_category_get_cvars"],
+	"description" : "MPI T_category_get_cvars Snippet",
+	"body" : [ "MPI_T_category_get_cvars( ${1:int cat_index}, ${2:int len}, ${3:int indices[]});"]
+},
+
+"MPI_T_category_get_events": {
+	"prefix": ["MPI_T_category_get_events"],
+	"description" : "MPI T_category_get_events Snippet",
+	"body" : [ "MPI_T_category_get_events( ${1:int cat_index}, ${2:int len}, ${3:int indices[]});"]
+},
+
+"MPI_T_category_get_index": {
+	"prefix": ["MPI_T_category_get_index"],
+	"description" : "MPI T_category_get_index Snippet",
+	"body" : [ "MPI_T_category_get_index( ${1:const char* name}, ${2:int* cat_index});"]
+},
+
+"MPI_T_category_get_info": {
+	"prefix": ["MPI_T_category_get_info"],
+	"description" : "MPI T_category_get_info Snippet",
+	"body" : [ "MPI_T_category_get_info( ${1:int cat_index}, ${2:char* name}, ${3:int* name_len}, ${4:char* desc}, ${5:int* desc_len}, ${6:int* num_cvars}, ${7:int* num_pvars}, ${8:int* num_categories});"]
+},
+
+"MPI_T_category_get_num": {
+	"prefix": ["MPI_T_category_get_num"],
+	"description" : "MPI T_category_get_num Snippet",
+	"body" : [ "MPI_T_category_get_num( ${1:int* num_cat});"]
+},
+
+"MPI_T_category_get_num_events": {
+	"prefix": ["MPI_T_category_get_num_events"],
+	"description" : "MPI T_category_get_num_events Snippet",
+	"body" : [ "MPI_T_category_get_num_events( ${1:int cat_index}, ${2:int* num_events});"]
+},
+
+"MPI_T_category_get_pvars": {
+	"prefix": ["MPI_T_category_get_pvars"],
+	"description" : "MPI T_category_get_pvars Snippet",
+	"body" : [ "MPI_T_category_get_pvars( ${1:int cat_index}, ${2:int len}, ${3:int indices[]});"]
+},
+
+"MPI_T_cvar_get_index": {
+	"prefix": ["MPI_T_cvar_get_index"],
+	"description" : "MPI T_cvar_get_index Snippet",
+	"body" : [ "MPI_T_cvar_get_index( ${1:const char* name}, ${2:int* cvar_index});"]
+},
+
+"MPI_T_cvar_get_info": {
+	"prefix": ["MPI_T_cvar_get_info"],
+	"description" : "MPI T_cvar_get_info Snippet",
+	"body" : [ "MPI_T_cvar_get_info( ${1:int cvar_index}, ${2:char* name}, ${3:int* name_len}, ${4:int* verbosity}, ${5:MPI_Datatype* datatype}, ${6:MPI_T_enum* enumtype}, ${7:char* desc}, ${8:int* desc_len}, ${9:int* bind}, ${10:int* scope});"]
+},
+
+"MPI_T_cvar_get_num": {
+	"prefix": ["MPI_T_cvar_get_num"],
+	"description" : "MPI T_cvar_get_num Snippet",
+	"body" : [ "MPI_T_cvar_get_num( ${1:int* num_cvar});"]
+},
+
+"MPI_T_cvar_handle_alloc": {
+	"prefix": ["MPI_T_cvar_handle_alloc"],
+	"description" : "MPI T_cvar_handle_alloc Snippet",
+	"body" : [ "MPI_T_cvar_handle_alloc( ${1:int cvar_index}, ${2:void* obj_handle}, ${3:MPI_T_cvar_handle* handle}, ${4:int* count});"]
+},
+
+"MPI_T_cvar_handle_free": {
+	"prefix": ["MPI_T_cvar_handle_free"],
+	"description" : "MPI T_cvar_handle_free Snippet",
+	"body" : [ "MPI_T_cvar_handle_free( ${1:MPI_T_cvar_handle* handle});"]
+},
+
+"MPI_T_cvar_read": {
+	"prefix": ["MPI_T_cvar_read"],
+	"description" : "MPI T_cvar_read Snippet",
+	"body" : [ "MPI_T_cvar_read( ${1:MPI_T_cvar_handle handle}, ${2:void* buf});"]
+},
+
+"MPI_T_cvar_write": {
+	"prefix": ["MPI_T_cvar_write"],
+	"description" : "MPI T_cvar_write Snippet",
+	"body" : [ "MPI_T_cvar_write( ${1:MPI_T_cvar_handle handle}, ${2:const void* buf});"]
+},
+
+"MPI_T_enum_get_info": {
+	"prefix": ["MPI_T_enum_get_info"],
+	"description" : "MPI T_enum_get_info Snippet",
+	"body" : [ "MPI_T_enum_get_info( ${1:MPI_T_enum enumtype}, ${2:int* num}, ${3:char* name}, ${4:int* name_len});"]
+},
+
+"MPI_T_enum_get_item": {
+	"prefix": ["MPI_T_enum_get_item"],
+	"description" : "MPI T_enum_get_item Snippet",
+	"body" : [ "MPI_T_enum_get_item( ${1:MPI_T_enum enumtype}, ${2:int index}, ${3:int* value}, ${4:char* name}, ${5:int* name_len});"]
+},
+
+"MPI_T_event_callback_get_info": {
+	"prefix": ["MPI_T_event_callback_get_info"],
+	"description" : "MPI T_event_callback_get_info Snippet",
+	"body" : [ "MPI_T_event_callback_get_info( ${1:MPI_T_event_registration event_registration}, ${2:MPI_T_cb_safety cb_safety}, ${3:MPI_Info* info_used});"]
+},
+
+"MPI_T_event_callback_set_info": {
+	"prefix": ["MPI_T_event_callback_set_info"],
+	"description" : "MPI T_event_callback_set_info Snippet",
+	"body" : [ "MPI_T_event_callback_set_info( ${1:MPI_T_event_registration event_registration}, ${2:MPI_T_cb_safety cb_safety}, ${3:MPI_Info info});"]
+},
+
+"MPI_T_event_copy": {
+	"prefix": ["MPI_T_event_copy"],
+	"description" : "MPI T_event_copy Snippet",
+	"body" : [ "MPI_T_event_copy( ${1:MPI_T_event_instance event_instance}, ${2:void* buffer});"]
+},
+
+"MPI_T_event_get_index": {
+	"prefix": ["MPI_T_event_get_index"],
+	"description" : "MPI T_event_get_index Snippet",
+	"body" : [ "MPI_T_event_get_index( ${1:const char* name}, ${2:int* event_index});"]
+},
+
+"MPI_T_event_get_info": {
+	"prefix": ["MPI_T_event_get_info"],
+	"description" : "MPI T_event_get_info Snippet",
+	"body" : [ "MPI_T_event_get_info( ${1:int event_index}, ${2:char* name}, ${3:int* name_len}, ${4:int* verbosity}, ${5:MPI_Datatype array_of_datatypes[]}, ${6:MPI_Aint array_of_displacements[]}, ${7:int* num_elements}, ${8:MPI_T_enum* enumtype}, ${9:MPI_Info* info}, ${10:char* desc}, ${11:int* desc_len}, ${12:int* bind});"]
+},
+
+"MPI_T_event_get_num": {
+	"prefix": ["MPI_T_event_get_num"],
+	"description" : "MPI T_event_get_num Snippet",
+	"body" : [ "MPI_T_event_get_num( ${1:int* num_events});"]
+},
+
+"MPI_T_event_get_source": {
+	"prefix": ["MPI_T_event_get_source"],
+	"description" : "MPI T_event_get_source Snippet",
+	"body" : [ "MPI_T_event_get_source( ${1:MPI_T_event_instance event_instance}, ${2:int* source_index});"]
+},
+
+"MPI_T_event_get_timestamp": {
+	"prefix": ["MPI_T_event_get_timestamp"],
+	"description" : "MPI T_event_get_timestamp Snippet",
+	"body" : [ "MPI_T_event_get_timestamp( ${1:MPI_T_event_instance event_instance}, ${2:MPI_Count* event_timestamp});"]
+},
+
+"MPI_T_event_handle_alloc": {
+	"prefix": ["MPI_T_event_handle_alloc"],
+	"description" : "MPI T_event_handle_alloc Snippet",
+	"body" : [ "MPI_T_event_handle_alloc( ${1:int event_index}, ${2:void* obj_handle}, ${3:MPI_Info info}, ${4:MPI_T_event_registration* event_registration});"]
+},
+
+"MPI_T_event_handle_free": {
+	"prefix": ["MPI_T_event_handle_free"],
+	"description" : "MPI T_event_handle_free Snippet",
+	"body" : [ "MPI_T_event_handle_free( ${1:MPI_T_event_registration event_registration}, ${2:void* user_data}, ${3:MPI_T_event_free_cb_function free_cb_function});"]
+},
+
+"MPI_T_event_handle_get_info": {
+	"prefix": ["MPI_T_event_handle_get_info"],
+	"description" : "MPI T_event_handle_get_info Snippet",
+	"body" : [ "MPI_T_event_handle_get_info( ${1:MPI_T_event_registration event_registration}, ${2:MPI_Info* info_used});"]
+},
+
+"MPI_T_event_handle_set_info": {
+	"prefix": ["MPI_T_event_handle_set_info"],
+	"description" : "MPI T_event_handle_set_info Snippet",
+	"body" : [ "MPI_T_event_handle_set_info( ${1:MPI_T_event_registration event_registration}, ${2:MPI_Info info});"]
+},
+
+"MPI_T_event_read": {
+	"prefix": ["MPI_T_event_read"],
+	"description" : "MPI T_event_read Snippet",
+	"body" : [ "MPI_T_event_read( ${1:MPI_T_event_instance event_instance}, ${2:int element_index}, ${3:void* buffer});"]
+},
+
+"MPI_T_event_register_callback": {
+	"prefix": ["MPI_T_event_register_callback"],
+	"description" : "MPI T_event_register_callback Snippet",
+	"body" : [ "MPI_T_event_register_callback( ${1:MPI_T_event_registration event_registration}, ${2:MPI_T_cb_safety cb_safety}, ${3:MPI_Info info}, ${4:void* user_data}, ${5:MPI_T_event_cb_function event_cb_function});"]
+},
+
+"MPI_T_event_set_dropped_handler": {
+	"prefix": ["MPI_T_event_set_dropped_handler"],
+	"description" : "MPI T_event_set_dropped_handler Snippet",
+	"body" : [ "MPI_T_event_set_dropped_handler( ${1:MPI_T_event_registration event_registration}, ${2:MPI_T_event_dropped_cb_function dropped_cb_function});"]
+},
+
+"MPI_T_finalize": {
+	"prefix": ["MPI_T_finalize"],
+	"description" : "MPI T_finalize Snippet",
+	"body" : [ "MPI_T_finalize();"]
+},
+
+"MPI_T_init_thread": {
+	"prefix": ["MPI_T_init_thread"],
+	"description" : "MPI T_init_thread Snippet",
+	"body" : [ "MPI_T_init_thread( ${1:int required}, ${2:int* provided});"]
+},
+
+"MPI_T_pvar_get_index": {
+	"prefix": ["MPI_T_pvar_get_index"],
+	"description" : "MPI T_pvar_get_index Snippet",
+	"body" : [ "MPI_T_pvar_get_index( ${1:const char* name}, ${2:int var_class}, ${3:int* pvar_index});"]
+},
+
+"MPI_T_pvar_get_info": {
+	"prefix": ["MPI_T_pvar_get_info"],
+	"description" : "MPI T_pvar_get_info Snippet",
+	"body" : [ "MPI_T_pvar_get_info( ${1:int pvar_index}, ${2:char* name}, ${3:int* name_len}, ${4:int* verbosity}, ${5:int* var_class}, ${6:MPI_Datatype* datatype}, ${7:MPI_T_enum* enumtype}, ${8:char* desc}, ${9:int* desc_len}, ${10:int* bind}, ${11:int* readonly}, ${12:int* continuous}, ${13:int* atomic});"]
+},
+
+"MPI_T_pvar_get_num": {
+	"prefix": ["MPI_T_pvar_get_num"],
+	"description" : "MPI T_pvar_get_num Snippet",
+	"body" : [ "MPI_T_pvar_get_num( ${1:int* num_pvar});"]
+},
+
+"MPI_T_pvar_handle_alloc": {
+	"prefix": ["MPI_T_pvar_handle_alloc"],
+	"description" : "MPI T_pvar_handle_alloc Snippet",
+	"body" : [ "MPI_T_pvar_handle_alloc( ${1:MPI_T_pvar_session pe_session}, ${2:int pvar_index}, ${3:void* obj_handle}, ${4:MPI_T_pvar_handle* handle}, ${5:int* count});"]
+},
+
+"MPI_T_pvar_handle_free": {
+	"prefix": ["MPI_T_pvar_handle_free"],
+	"description" : "MPI T_pvar_handle_free Snippet",
+	"body" : [ "MPI_T_pvar_handle_free( ${1:MPI_T_pvar_session pe_session}, ${2:MPI_T_pvar_handle* handle});"]
+},
+
+"MPI_T_pvar_read": {
+	"prefix": ["MPI_T_pvar_read"],
+	"description" : "MPI T_pvar_read Snippet",
+	"body" : [ "MPI_T_pvar_read( ${1:MPI_T_pvar_session pe_session}, ${2:MPI_T_pvar_handle handle}, ${3:void* buf});"]
+},
+
+"MPI_T_pvar_readreset": {
+	"prefix": ["MPI_T_pvar_readreset"],
+	"description" : "MPI T_pvar_readreset Snippet",
+	"body" : [ "MPI_T_pvar_readreset( ${1:MPI_T_pvar_session pe_session}, ${2:MPI_T_pvar_handle handle}, ${3:void* buf});"]
+},
+
+"MPI_T_pvar_reset": {
+	"prefix": ["MPI_T_pvar_reset"],
+	"description" : "MPI T_pvar_reset Snippet",
+	"body" : [ "MPI_T_pvar_reset( ${1:MPI_T_pvar_session pe_session}, ${2:MPI_T_pvar_handle handle});"]
+},
+
+"MPI_T_pvar_session_create": {
+	"prefix": ["MPI_T_pvar_session_create"],
+	"description" : "MPI T_pvar_session_create Snippet",
+	"body" : [ "MPI_T_pvar_session_create( ${1:MPI_T_pvar_session* pe_session});"]
+},
+
+"MPI_T_pvar_session_free": {
+	"prefix": ["MPI_T_pvar_session_free"],
+	"description" : "MPI T_pvar_session_free Snippet",
+	"body" : [ "MPI_T_pvar_session_free( ${1:MPI_T_pvar_session* pe_session});"]
+},
+
+"MPI_T_pvar_start": {
+	"prefix": ["MPI_T_pvar_start"],
+	"description" : "MPI T_pvar_start Snippet",
+	"body" : [ "MPI_T_pvar_start( ${1:MPI_T_pvar_session pe_session}, ${2:MPI_T_pvar_handle handle});"]
+},
+
+"MPI_T_pvar_stop": {
+	"prefix": ["MPI_T_pvar_stop"],
+	"description" : "MPI T_pvar_stop Snippet",
+	"body" : [ "MPI_T_pvar_stop( ${1:MPI_T_pvar_session pe_session}, ${2:MPI_T_pvar_handle handle});"]
+},
+
+"MPI_T_pvar_write": {
+	"prefix": ["MPI_T_pvar_write"],
+	"description" : "MPI T_pvar_write Snippet",
+	"body" : [ "MPI_T_pvar_write( ${1:MPI_T_pvar_session pe_session}, ${2:MPI_T_pvar_handle handle}, ${3:const void* buf});"]
+},
+
+"MPI_T_source_get_info": {
+	"prefix": ["MPI_T_source_get_info"],
+	"description" : "MPI T_source_get_info Snippet",
+	"body" : [ "MPI_T_source_get_info( ${1:int source_index}, ${2:char* name}, ${3:int* name_len}, ${4:char* desc}, ${5:int* desc_len}, ${6:MPI_T_source_order* ordering}, ${7:MPI_Count* ticks_per_second}, ${8:MPI_Count* max_ticks}, ${9:MPI_Info* info});"]
+},
+
+"MPI_T_source_get_num": {
+	"prefix": ["MPI_T_source_get_num"],
+	"description" : "MPI T_source_get_num Snippet",
+	"body" : [ "MPI_T_source_get_num( ${1:int* num_sources});"]
+},
+
+"MPI_T_source_get_timestamp": {
+	"prefix": ["MPI_T_source_get_timestamp"],
+	"description" : "MPI T_source_get_timestamp Snippet",
+	"body" : [ "MPI_T_source_get_timestamp( ${1:int source_index}, ${2:MPI_Count* timestamp});"]
+},
+
+"MPI_Test": {
+	"prefix": ["MPI_Test"],
+	"description" : "MPI Test Snippet",
+	"body" : [ "MPI_Test( ${1:MPI_Request* request}, ${2:int* flag}, ${3:MPI_Status* status});"]
+},
+
+"MPI_Test_cancelled": {
+	"prefix": ["MPI_Test_cancelled"],
+	"description" : "MPI Test_cancelled Snippet",
+	"body" : [ "MPI_Test_cancelled( ${1:const MPI_Status* status}, ${2:int* flag});"]
+},
+
+"MPI_Testall": {
+	"prefix": ["MPI_Testall"],
+	"description" : "MPI Testall Snippet",
+	"body" : [ "MPI_Testall( ${1:int count}, ${2:MPI_Request array_of_requests[]}, ${3:int* flag}, ${4:MPI_Status array_of_statuses[]});"]
+},
+
+"MPI_Testany": {
+	"prefix": ["MPI_Testany"],
+	"description" : "MPI Testany Snippet",
+	"body" : [ "MPI_Testany( ${1:int count}, ${2:MPI_Request array_of_requests[]}, ${3:int* index}, ${4:int* flag}, ${5:MPI_Status* status});"]
+},
+
+"MPI_Testsome": {
+	"prefix": ["MPI_Testsome"],
+	"description" : "MPI Testsome Snippet",
+	"body" : [ "MPI_Testsome( ${1:int incount}, ${2:MPI_Request array_of_requests[]}, ${3:int* outcount}, ${4:int array_of_indices[]}, ${5:MPI_Status array_of_statuses[]});"]
+},
+
+"MPI_Topo_test": {
+	"prefix": ["MPI_Topo_test"],
+	"description" : "MPI Topo_test Snippet",
+	"body" : [ "MPI_Topo_test( ${1:MPI_Comm comm}, ${2:int* status});"]
+},
+
+"MPI_Type_commit": {
+	"prefix": ["MPI_Type_commit"],
+	"description" : "MPI Type_commit Snippet",
+	"body" : [ "MPI_Type_commit( ${1:MPI_Datatype* datatype});"]
+},
+
+"MPI_Type_contiguous": {
+	"prefix": ["MPI_Type_contiguous"],
+	"description" : "MPI Type_contiguous Snippet",
+	"body" : [ "MPI_Type_contiguous( ${1:MPI_Count count}, ${2:MPI_Datatype oldtype}, ${3:MPI_Datatype* newtype});"]
+},
+
+"MPI_Type_create_darray": {
+	"prefix": ["MPI_Type_create_darray"],
+	"description" : "MPI Type_create_darray Snippet",
+	"body" : [ "MPI_Type_create_darray( ${1:int size}, ${2:int rank}, ${3:int ndims}, ${4:const MPI_Count array_of_gsizes[]}, ${5:const int array_of_distribs[]}, ${6:const int array_of_dargs[]}, ${7:const int array_of_psizes[]}, ${8:int order}, ${9:MPI_Datatype oldtype}, ${10:MPI_Datatype* newtype});"]
+},
+
+"MPI_Type_create_f90_complex": {
+	"prefix": ["MPI_Type_create_f90_complex"],
+	"description" : "MPI Type_create_f90_complex Snippet",
+	"body" : [ "MPI_Type_create_f90_complex( ${1:int p}, ${2:int r}, ${3:MPI_Datatype* newtype});"]
+},
+
+"MPI_Type_create_f90_integer": {
+	"prefix": ["MPI_Type_create_f90_integer"],
+	"description" : "MPI Type_create_f90_integer Snippet",
+	"body" : [ "MPI_Type_create_f90_integer( ${1:int r}, ${2:MPI_Datatype* newtype});"]
+},
+
+"MPI_Type_create_f90_real": {
+	"prefix": ["MPI_Type_create_f90_real"],
+	"description" : "MPI Type_create_f90_real Snippet",
+	"body" : [ "MPI_Type_create_f90_real( ${1:int p}, ${2:int r}, ${3:MPI_Datatype* newtype});"]
+},
+
+"MPI_Type_create_hindexed": {
+	"prefix": ["MPI_Type_create_hindexed"],
+	"description" : "MPI Type_create_hindexed Snippet",
+	"body" : [ "MPI_Type_create_hindexed( ${1:MPI_Count count}, ${2:const MPI_Count array_of_blocklengths[]}, ${3:const MPI_Count array_of_displacements[]}, ${4:MPI_Datatype oldtype}, ${5:MPI_Datatype* newtype});"]
+},
+
+"MPI_Type_create_hindexed_block": {
+	"prefix": ["MPI_Type_create_hindexed_block"],
+	"description" : "MPI Type_create_hindexed_block Snippet",
+	"body" : [ "MPI_Type_create_hindexed_block( ${1:MPI_Count count}, ${2:MPI_Count blocklength}, ${3:const MPI_Count array_of_displacements[]}, ${4:MPI_Datatype oldtype}, ${5:MPI_Datatype* newtype});"]
+},
+
+"MPI_Type_create_hvector": {
+	"prefix": ["MPI_Type_create_hvector"],
+	"description" : "MPI Type_create_hvector Snippet",
+	"body" : [ "MPI_Type_create_hvector( ${1:MPI_Count count}, ${2:MPI_Count blocklength}, ${3:MPI_Count stride}, ${4:MPI_Datatype oldtype}, ${5:MPI_Datatype* newtype});"]
+},
+
+"MPI_Type_create_indexed_block": {
+	"prefix": ["MPI_Type_create_indexed_block"],
+	"description" : "MPI Type_create_indexed_block Snippet",
+	"body" : [ "MPI_Type_create_indexed_block( ${1:MPI_Count count}, ${2:MPI_Count blocklength}, ${3:const MPI_Count array_of_displacements[]}, ${4:MPI_Datatype oldtype}, ${5:MPI_Datatype* newtype});"]
+},
+
+"MPI_Type_create_keyval": {
+	"prefix": ["MPI_Type_create_keyval"],
+	"description" : "MPI Type_create_keyval Snippet",
+	"body" : [ "MPI_Type_create_keyval( ${1:MPI_Type_copy_attr_function* type_copy_attr_fn}, ${2:MPI_Type_delete_attr_function* type_delete_attr_fn}, ${3:int* type_keyval}, ${4:void* extra_state});"]
+},
+
+"MPI_Type_create_resized": {
+	"prefix": ["MPI_Type_create_resized"],
+	"description" : "MPI Type_create_resized Snippet",
+	"body" : [ "MPI_Type_create_resized( ${1:MPI_Datatype oldtype}, ${2:MPI_Count lb}, ${3:MPI_Count extent}, ${4:MPI_Datatype* newtype});"]
+},
+
+"MPI_Type_create_struct": {
+	"prefix": ["MPI_Type_create_struct"],
+	"description" : "MPI Type_create_struct Snippet",
+	"body" : [ "MPI_Type_create_struct( ${1:MPI_Count count}, ${2:const MPI_Count array_of_blocklengths[]}, ${3:const MPI_Count array_of_displacements[]}, ${4:const MPI_Datatype array_of_types[]}, ${5:MPI_Datatype* newtype});"]
+},
+
+"MPI_Type_create_subarray": {
+	"prefix": ["MPI_Type_create_subarray"],
+	"description" : "MPI Type_create_subarray Snippet",
+	"body" : [ "MPI_Type_create_subarray( ${1:int ndims}, ${2:const MPI_Count array_of_sizes[]}, ${3:const MPI_Count array_of_subsizes[]}, ${4:const MPI_Count array_of_starts[]}, ${5:int order}, ${6:MPI_Datatype oldtype}, ${7:MPI_Datatype* newtype});"]
+},
+
+"MPI_Type_delete_attr": {
+	"prefix": ["MPI_Type_delete_attr"],
+	"description" : "MPI Type_delete_attr Snippet",
+	"body" : [ "MPI_Type_delete_attr( ${1:MPI_Datatype datatype}, ${2:int type_keyval});"]
+},
+
+"MPI_Type_dup": {
+	"prefix": ["MPI_Type_dup"],
+	"description" : "MPI Type_dup Snippet",
+	"body" : [ "MPI_Type_dup( ${1:MPI_Datatype oldtype}, ${2:MPI_Datatype* newtype});"]
+},
+
+"MPI_Type_free": {
+	"prefix": ["MPI_Type_free"],
+	"description" : "MPI Type_free Snippet",
+	"body" : [ "MPI_Type_free( ${1:MPI_Datatype* datatype});"]
+},
+
+"MPI_Type_free_keyval": {
+	"prefix": ["MPI_Type_free_keyval"],
+	"description" : "MPI Type_free_keyval Snippet",
+	"body" : [ "MPI_Type_free_keyval( ${1:int* type_keyval});"]
+},
+
+"MPI_Type_get_attr": {
+	"prefix": ["MPI_Type_get_attr"],
+	"description" : "MPI Type_get_attr Snippet",
+	"body" : [ "MPI_Type_get_attr( ${1:MPI_Datatype datatype}, ${2:int type_keyval}, ${3:void* attribute_val}, ${4:int* flag});"]
+},
+
+"MPI_Type_get_contents": {
+	"prefix": ["MPI_Type_get_contents"],
+	"description" : "MPI Type_get_contents Snippet",
+	"body" : [ "MPI_Type_get_contents( ${1:MPI_Datatype datatype}, ${2:MPI_Count max_integers}, ${3:MPI_Count max_addresses}, ${4:MPI_Count max_large_counts}, ${5:MPI_Count max_datatypes}, ${6:int array_of_integers[]}, ${7:MPI_Aint array_of_addresses[]}, ${8:MPI_Count array_of_large_counts[]}, ${9:MPI_Datatype array_of_datatypes[]});"]
+},
+
+"MPI_Type_get_envelope": {
+	"prefix": ["MPI_Type_get_envelope"],
+	"description" : "MPI Type_get_envelope Snippet",
+	"body" : [ "MPI_Type_get_envelope( ${1:MPI_Datatype datatype}, ${2:MPI_Count* num_integers}, ${3:MPI_Count* num_addresses}, ${4:MPI_Count* num_large_counts}, ${5:MPI_Count* num_datatypes}, ${6:int* combiner});"]
+},
+
+"MPI_Type_get_extent": {
+	"prefix": ["MPI_Type_get_extent"],
+	"description" : "MPI Type_get_extent Snippet",
+	"body" : [ "MPI_Type_get_extent( ${1:MPI_Datatype datatype}, ${2:MPI_Count* lb}, ${3:MPI_Count* extent});"]
+},
+
+"MPI_Type_get_extent_x": {
+	"prefix": ["MPI_Type_get_extent_x"],
+	"description" : "MPI Type_get_extent_x Snippet",
+	"body" : [ "MPI_Type_get_extent_x( ${1:MPI_Datatype datatype}, ${2:MPI_Count* lb}, ${3:MPI_Count* extent});"]
+},
+
+"MPI_Type_get_name": {
+	"prefix": ["MPI_Type_get_name"],
+	"description" : "MPI Type_get_name Snippet",
+	"body" : [ "MPI_Type_get_name( ${1:MPI_Datatype datatype}, ${2:char* type_name}, ${3:int* resultlen});"]
+},
+
+"MPI_Type_get_true_extent": {
+	"prefix": ["MPI_Type_get_true_extent"],
+	"description" : "MPI Type_get_true_extent Snippet",
+	"body" : [ "MPI_Type_get_true_extent( ${1:MPI_Datatype datatype}, ${2:MPI_Count* true_lb}, ${3:MPI_Count* true_extent});"]
+},
+
+"MPI_Type_get_true_extent_x": {
+	"prefix": ["MPI_Type_get_true_extent_x"],
+	"description" : "MPI Type_get_true_extent_x Snippet",
+	"body" : [ "MPI_Type_get_true_extent_x( ${1:MPI_Datatype datatype}, ${2:MPI_Count* true_lb}, ${3:MPI_Count* true_extent});"]
+},
+
+"MPI_Type_indexed": {
+	"prefix": ["MPI_Type_indexed"],
+	"description" : "MPI Type_indexed Snippet",
+	"body" : [ "MPI_Type_indexed( ${1:MPI_Count count}, ${2:const MPI_Count array_of_blocklengths[]}, ${3:const MPI_Count array_of_displacements[]}, ${4:MPI_Datatype oldtype}, ${5:MPI_Datatype* newtype});"]
+},
+
+"MPI_Type_match_size": {
+	"prefix": ["MPI_Type_match_size"],
+	"description" : "MPI Type_match_size Snippet",
+	"body" : [ "MPI_Type_match_size( ${1:int typeclass}, ${2:int size}, ${3:MPI_Datatype* datatype});"]
+},
+
+"MPI_Type_set_attr": {
+	"prefix": ["MPI_Type_set_attr"],
+	"description" : "MPI Type_set_attr Snippet",
+	"body" : [ "MPI_Type_set_attr( ${1:MPI_Datatype datatype}, ${2:int type_keyval}, ${3:void* attribute_val});"]
+},
+
+"MPI_Type_set_name": {
+	"prefix": ["MPI_Type_set_name"],
+	"description" : "MPI Type_set_name Snippet",
+	"body" : [ "MPI_Type_set_name( ${1:MPI_Datatype datatype}, ${2:const char* type_name});"]
+},
+
+"MPI_Type_size": {
+	"prefix": ["MPI_Type_size"],
+	"description" : "MPI Type_size Snippet",
+	"body" : [ "MPI_Type_size( ${1:MPI_Datatype datatype}, ${2:MPI_Count* size});"]
+},
+
+"MPI_Type_size_x": {
+	"prefix": ["MPI_Type_size_x"],
+	"description" : "MPI Type_size_x Snippet",
+	"body" : [ "MPI_Type_size_x( ${1:MPI_Datatype datatype}, ${2:MPI_Count* size});"]
+},
+
+"MPI_Type_vector": {
+	"prefix": ["MPI_Type_vector"],
+	"description" : "MPI Type_vector Snippet",
+	"body" : [ "MPI_Type_vector( ${1:MPI_Count count}, ${2:MPI_Count blocklength}, ${3:MPI_Count stride}, ${4:MPI_Datatype oldtype}, ${5:MPI_Datatype* newtype});"]
+},
+
+"MPI_Unpack": {
+	"prefix": ["MPI_Unpack"],
+	"description" : "MPI Unpack Snippet",
+	"body" : [ "MPI_Unpack( ${1:const void* inbuf}, ${2:MPI_Count insize}, ${3:MPI_Count* position}, ${4:void* outbuf}, ${5:MPI_Count outcount}, ${6:MPI_Datatype datatype}, ${7:MPI_Comm comm});"]
+},
+
+"MPI_Unpack_external": {
+	"prefix": ["MPI_Unpack_external"],
+	"description" : "MPI Unpack_external Snippet",
+	"body" : [ "MPI_Unpack_external( ${1:const char datarep[]}, ${2:const void* inbuf}, ${3:MPI_Count insize}, ${4:MPI_Count* position}, ${5:void* outbuf}, ${6:MPI_Count outcount}, ${7:MPI_Datatype datatype});"]
+},
+
+"MPI_Unpublish_name": {
+	"prefix": ["MPI_Unpublish_name"],
+	"description" : "MPI Unpublish_name Snippet",
+	"body" : [ "MPI_Unpublish_name( ${1:const char* service_name}, ${2:MPI_Info info}, ${3:const char* port_name});"]
+},
+
+"MPI_Wait": {
+	"prefix": ["MPI_Wait"],
+	"description" : "MPI Wait Snippet",
+	"body" : [ "MPI_Wait( ${1:MPI_Request* request}, ${2:MPI_Status* status});"]
+},
+
+"MPI_Waitall": {
+	"prefix": ["MPI_Waitall"],
+	"description" : "MPI Waitall Snippet",
+	"body" : [ "MPI_Waitall( ${1:int count}, ${2:MPI_Request array_of_requests[]}, ${3:MPI_Status array_of_statuses[]});"]
+},
+
+"MPI_Waitany": {
+	"prefix": ["MPI_Waitany"],
+	"description" : "MPI Waitany Snippet",
+	"body" : [ "MPI_Waitany( ${1:int count}, ${2:MPI_Request array_of_requests[]}, ${3:int* index}, ${4:MPI_Status* status});"]
+},
+
+"MPI_Waitsome": {
+	"prefix": ["MPI_Waitsome"],
+	"description" : "MPI Waitsome Snippet",
+	"body" : [ "MPI_Waitsome( ${1:int incount}, ${2:MPI_Request array_of_requests[]}, ${3:int* outcount}, ${4:int array_of_indices[]}, ${5:MPI_Status array_of_statuses[]});"]
+},
+
+"MPI_Win_allocate": {
+	"prefix": ["MPI_Win_allocate"],
+	"description" : "MPI Win_allocate Snippet",
+	"body" : [ "MPI_Win_allocate( ${1:MPI_Aint size}, ${2:MPI_Aint disp_unit}, ${3:MPI_Info info}, ${4:MPI_Comm comm}, ${5:void* baseptr}, ${6:MPI_Win* win});"]
+},
+
+"MPI_Win_allocate_shared": {
+	"prefix": ["MPI_Win_allocate_shared"],
+	"description" : "MPI Win_allocate_shared Snippet",
+	"body" : [ "MPI_Win_allocate_shared( ${1:MPI_Aint size}, ${2:MPI_Aint disp_unit}, ${3:MPI_Info info}, ${4:MPI_Comm comm}, ${5:void* baseptr}, ${6:MPI_Win* win});"]
+},
+
+"MPI_Win_attach": {
+	"prefix": ["MPI_Win_attach"],
+	"description" : "MPI Win_attach Snippet",
+	"body" : [ "MPI_Win_attach( ${1:MPI_Win win}, ${2:void* base}, ${3:MPI_Aint size});"]
+},
+
+"MPI_Win_call_errhandler": {
+	"prefix": ["MPI_Win_call_errhandler"],
+	"description" : "MPI Win_call_errhandler Snippet",
+	"body" : [ "MPI_Win_call_errhandler( ${1:MPI_Win win}, ${2:int errorcode});"]
+},
+
+"MPI_Win_complete": {
+	"prefix": ["MPI_Win_complete"],
+	"description" : "MPI Win_complete Snippet",
+	"body" : [ "MPI_Win_complete( ${1:MPI_Win win});"]
+},
+
+"MPI_Win_create": {
+	"prefix": ["MPI_Win_create"],
+	"description" : "MPI Win_create Snippet",
+	"body" : [ "MPI_Win_create( ${1:void* base}, ${2:MPI_Aint size}, ${3:MPI_Aint disp_unit}, ${4:MPI_Info info}, ${5:MPI_Comm comm}, ${6:MPI_Win* win});"]
+},
+
+"MPI_Win_create_dynamic": {
+	"prefix": ["MPI_Win_create_dynamic"],
+	"description" : "MPI Win_create_dynamic Snippet",
+	"body" : [ "MPI_Win_create_dynamic( ${1:MPI_Info info}, ${2:MPI_Comm comm}, ${3:MPI_Win* win});"]
+},
+
+"MPI_Win_create_errhandler": {
+	"prefix": ["MPI_Win_create_errhandler"],
+	"description" : "MPI Win_create_errhandler Snippet",
+	"body" : [ "MPI_Win_create_errhandler( ${1:MPI_Win_errhandler_function* win_errhandler_fn}, ${2:MPI_Errhandler* errhandler});"]
+},
+
+"MPI_Win_create_keyval": {
+	"prefix": ["MPI_Win_create_keyval"],
+	"description" : "MPI Win_create_keyval Snippet",
+	"body" : [ "MPI_Win_create_keyval( ${1:MPI_Win_copy_attr_function* win_copy_attr_fn}, ${2:MPI_Win_delete_attr_function* win_delete_attr_fn}, ${3:int* win_keyval}, ${4:void* extra_state});"]
+},
+
+"MPI_Win_delete_attr": {
+	"prefix": ["MPI_Win_delete_attr"],
+	"description" : "MPI Win_delete_attr Snippet",
+	"body" : [ "MPI_Win_delete_attr( ${1:MPI_Win win}, ${2:int win_keyval});"]
+},
+
+"MPI_Win_detach": {
+	"prefix": ["MPI_Win_detach"],
+	"description" : "MPI Win_detach Snippet",
+	"body" : [ "MPI_Win_detach( ${1:MPI_Win win}, ${2:const void* base});"]
+},
+
+"MPI_Win_fence": {
+	"prefix": ["MPI_Win_fence"],
+	"description" : "MPI Win_fence Snippet",
+	"body" : [ "MPI_Win_fence( ${1:int assert}, ${2:MPI_Win win});"]
+},
+
+"MPI_Win_flush": {
+	"prefix": ["MPI_Win_flush"],
+	"description" : "MPI Win_flush Snippet",
+	"body" : [ "MPI_Win_flush( ${1:int rank}, ${2:MPI_Win win});"]
+},
+
+"MPI_Win_flush_all": {
+	"prefix": ["MPI_Win_flush_all"],
+	"description" : "MPI Win_flush_all Snippet",
+	"body" : [ "MPI_Win_flush_all( ${1:MPI_Win win});"]
+},
+
+"MPI_Win_flush_local": {
+	"prefix": ["MPI_Win_flush_local"],
+	"description" : "MPI Win_flush_local Snippet",
+	"body" : [ "MPI_Win_flush_local( ${1:int rank}, ${2:MPI_Win win});"]
+},
+
+"MPI_Win_flush_local_all": {
+	"prefix": ["MPI_Win_flush_local_all"],
+	"description" : "MPI Win_flush_local_all Snippet",
+	"body" : [ "MPI_Win_flush_local_all( ${1:MPI_Win win});"]
+},
+
+"MPI_Win_free": {
+	"prefix": ["MPI_Win_free"],
+	"description" : "MPI Win_free Snippet",
+	"body" : [ "MPI_Win_free( ${1:MPI_Win* win});"]
+},
+
+"MPI_Win_free_keyval": {
+	"prefix": ["MPI_Win_free_keyval"],
+	"description" : "MPI Win_free_keyval Snippet",
+	"body" : [ "MPI_Win_free_keyval( ${1:int* win_keyval});"]
+},
+
+"MPI_Win_get_attr": {
+	"prefix": ["MPI_Win_get_attr"],
+	"description" : "MPI Win_get_attr Snippet",
+	"body" : [ "MPI_Win_get_attr( ${1:MPI_Win win}, ${2:int win_keyval}, ${3:void* attribute_val}, ${4:int* flag});"]
+},
+
+"MPI_Win_get_errhandler": {
+	"prefix": ["MPI_Win_get_errhandler"],
+	"description" : "MPI Win_get_errhandler Snippet",
+	"body" : [ "MPI_Win_get_errhandler( ${1:MPI_Win win}, ${2:MPI_Errhandler* errhandler});"]
+},
+
+"MPI_Win_get_group": {
+	"prefix": ["MPI_Win_get_group"],
+	"description" : "MPI Win_get_group Snippet",
+	"body" : [ "MPI_Win_get_group( ${1:MPI_Win win}, ${2:MPI_Group* group});"]
+},
+
+"MPI_Win_get_info": {
+	"prefix": ["MPI_Win_get_info"],
+	"description" : "MPI Win_get_info Snippet",
+	"body" : [ "MPI_Win_get_info( ${1:MPI_Win win}, ${2:MPI_Info* info_used});"]
+},
+
+"MPI_Win_get_name": {
+	"prefix": ["MPI_Win_get_name"],
+	"description" : "MPI Win_get_name Snippet",
+	"body" : [ "MPI_Win_get_name( ${1:MPI_Win win}, ${2:char* win_name}, ${3:int* resultlen});"]
+},
+
+"MPI_Win_lock": {
+	"prefix": ["MPI_Win_lock"],
+	"description" : "MPI Win_lock Snippet",
+	"body" : [ "MPI_Win_lock( ${1:int lock_type}, ${2:int rank}, ${3:int assert}, ${4:MPI_Win win});"]
+},
+
+"MPI_Win_lock_all": {
+	"prefix": ["MPI_Win_lock_all"],
+	"description" : "MPI Win_lock_all Snippet",
+	"body" : [ "MPI_Win_lock_all( ${1:int assert}, ${2:MPI_Win win});"]
+},
+
+"MPI_Win_post": {
+	"prefix": ["MPI_Win_post"],
+	"description" : "MPI Win_post Snippet",
+	"body" : [ "MPI_Win_post( ${1:MPI_Group group}, ${2:int assert}, ${3:MPI_Win win});"]
+},
+
+"MPI_Win_set_attr": {
+	"prefix": ["MPI_Win_set_attr"],
+	"description" : "MPI Win_set_attr Snippet",
+	"body" : [ "MPI_Win_set_attr( ${1:MPI_Win win}, ${2:int win_keyval}, ${3:void* attribute_val});"]
+},
+
+"MPI_Win_set_errhandler": {
+	"prefix": ["MPI_Win_set_errhandler"],
+	"description" : "MPI Win_set_errhandler Snippet",
+	"body" : [ "MPI_Win_set_errhandler( ${1:MPI_Win win}, ${2:MPI_Errhandler errhandler});"]
+},
+
+"MPI_Win_set_info": {
+	"prefix": ["MPI_Win_set_info"],
+	"description" : "MPI Win_set_info Snippet",
+	"body" : [ "MPI_Win_set_info( ${1:MPI_Win win}, ${2:MPI_Info info});"]
+},
+
+"MPI_Win_set_name": {
+	"prefix": ["MPI_Win_set_name"],
+	"description" : "MPI Win_set_name Snippet",
+	"body" : [ "MPI_Win_set_name( ${1:MPI_Win win}, ${2:const char* win_name});"]
+},
+
+"MPI_Win_shared_query": {
+	"prefix": ["MPI_Win_shared_query"],
+	"description" : "MPI Win_shared_query Snippet",
+	"body" : [ "MPI_Win_shared_query( ${1:MPI_Win win}, ${2:int rank}, ${3:MPI_Aint* size}, ${4:MPI_Aint* disp_unit}, ${5:void* baseptr});"]
+},
+
+"MPI_Win_start": {
+	"prefix": ["MPI_Win_start"],
+	"description" : "MPI Win_start Snippet",
+	"body" : [ "MPI_Win_start( ${1:MPI_Group group}, ${2:int assert}, ${3:MPI_Win win});"]
+},
+
+"MPI_Win_sync": {
+	"prefix": ["MPI_Win_sync"],
+	"description" : "MPI Win_sync Snippet",
+	"body" : [ "MPI_Win_sync( ${1:MPI_Win win});"]
+},
+
 "MPI_Win_test": {
 	"prefix": ["MPI_Win_test"],
 	"description" : "MPI Win_test Snippet",
 	"body" : [ "MPI_Win_test( ${1:MPI_Win win}, ${2:int* flag});"]
 },
 
-"MPI_Type_create_hindexed": {
-	"prefix": ["MPI_Type_create_hindexed"],
-	"description" : "MPI Type_create_hindexed Snippet",
-	"body" : [ "MPI_Type_create_hindexed( ${1:int count}, ${2:int array_of_blocklengths[]}, ${3:MPI_Aint array_of_displacements[]}, ${4:MPI_Datatype oldtype}, ${5:MPI_Datatype* newtype});"]
+"MPI_Win_unlock": {
+	"prefix": ["MPI_Win_unlock"],
+	"description" : "MPI Win_unlock Snippet",
+	"body" : [ "MPI_Win_unlock( ${1:int rank}, ${2:MPI_Win win});"]
 },
 
-"MPI_Type_match_size": {
-	"prefix": ["MPI_Type_match_size"],
-	"description" : "MPI Type_match_size Snippet",
-	"body" : [ "MPI_Type_match_size( ${1:int typeclass}, ${2:int size}, ${3:MPI_Datatype* type});"]
+"MPI_Win_unlock_all": {
+	"prefix": ["MPI_Win_unlock_all"],
+	"description" : "MPI Win_unlock_all Snippet",
+	"body" : [ "MPI_Win_unlock_all( ${1:MPI_Win win});"]
 },
 
-"MPI_Send": {
-	"prefix": ["MPI_Send"],
-	"description" : "MPI Send Snippet",
-	"body" : [ "MPI_Send( ${1:void* buf}, ${2:int count}, ${3:MPI_Datatype datatype}, ${4:int dest}, ${5:int tag}, ${6:MPI_Comm comm});"]
+"MPI_Win_wait": {
+	"prefix": ["MPI_Win_wait"],
+	"description" : "MPI Win_wait Snippet",
+	"body" : [ "MPI_Win_wait( ${1:MPI_Win win});"]
+},
+
+"MPI_Wtick": {
+	"prefix": ["MPI_Wtick"],
+	"description" : "MPI Wtick Snippet",
+	"body" : [ "MPI_Wtick();"]
+},
+
+"MPI_Wtime": {
+	"prefix": ["MPI_Wtime"],
+	"description" : "MPI Wtime Snippet",
+	"body" : [ "MPI_Wtime();"]
 },
 
 "Main() MPI" : {

--- a/UltiSnips/c.snippets
+++ b/UltiSnips/c.snippets
@@ -1,752 +1,68 @@
-snippet MPI_Start
-MPI_Start( ${1:MPI_Request* request} );
+snippet MPI_Abort
+MPI_Abort( ${1:MPI_Comm comm} , ${2:int errorcode} );
 endsnippet
-snippet MPI_File_write_all_begin
-MPI_File_write_all_begin( ${1:MPI_File fh} , ${2:void* buf} , ${3:int count} , ${4:MPI_Datatype datatype} );
-endsnippet
-snippet MPI_Win_post
-MPI_Win_post( ${1:MPI_Group group} , ${2:int assert} , ${3:MPI_Win win} );
-endsnippet
-snippet MPI_Win_get_errhandler
-MPI_Win_get_errhandler( ${1:MPI_Win win} , ${2:MPI_Errhandler* errhandler} );
-endsnippet
-snippet MPI_File_get_group
-MPI_File_get_group( ${1:MPI_File fh} , ${2:MPI_Group* group} );
-endsnippet
-snippet MPI_Scan
-MPI_Scan( ${1:void* sendbuf} , ${2:void* recvbuf} , ${3:int count} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:MPI_Comm comm} );
-endsnippet
-snippet MPI_Startall
-MPI_Startall( ${1:int count} , ${2:MPI_Request array_of_requests[]} );
-endsnippet
-snippet MPI_Attr_delete
-MPI_Attr_delete( ${1:MPI_Comm comm} , ${2:int keyval} );
-endsnippet
-snippet MPI_File_iwrite_shared
-MPI_File_iwrite_shared( ${1:MPI_File fh} , ${2:void* buf} , ${3:int count} , ${4:MPI_Datatype datatype} , ${5:MPI_Request* request} );
-endsnippet
-snippet MPI_Comm_get_attr
-MPI_Comm_get_attr( ${1:MPI_Comm comm} , ${2:int comm_keyval} , ${3:void* attribute_val} , ${4:int* flag} );
-endsnippet
-snippet MPI_File_get_info
-MPI_File_get_info( ${1:MPI_File fh} , ${2:MPI_Info* info_used} );
-endsnippet
-snippet MPI_Type_delete_attr
-MPI_Type_delete_attr( ${1:MPI_Datatype type} , ${2:int type_keyval} );
-endsnippet
-snippet MPI_Error_class
-MPI_Error_class( ${1:int errorcode} , ${2:int* errorclass} );
-endsnippet
-snippet MPI_Free_mem
-MPI_Free_mem( ${1:void* base} );
-endsnippet
-snippet MPI_Info_dup
-MPI_Info_dup( ${1:MPI_Info info} , ${2:MPI_Info* newinfo} );
-endsnippet
-snippet MPI_Type_lb
-MPI_Type_lb( ${1:MPI_Datatype type} , ${2:MPI_Aint* lb} );
-endsnippet
-snippet MPI_Cart_get
-MPI_Cart_get( ${1:MPI_Comm comm} , ${2:int maxdims} , ${3:int dims[]} , ${4:int periods[]} , ${5:int coords[]} );
+snippet MPI_Accumulate
+MPI_Accumulate( ${1:const void* origin_addr} , ${2:MPI_Count origin_count} , ${3:MPI_Datatype origin_datatype} , ${4:int target_rank} , ${5:MPI_Aint target_disp} , ${6:MPI_Count target_count} , ${7:MPI_Datatype target_datatype} , ${8:MPI_Op op} , ${9:MPI_Win win} );
 endsnippet
 snippet MPI_Add_error_class
 MPI_Add_error_class( ${1:int* errorclass} );
 endsnippet
-snippet MPI_File_write_shared
-MPI_File_write_shared( ${1:MPI_File fh} , ${2:void* buf} , ${3:int count} , ${4:MPI_Datatype datatype} , ${5:MPI_Status* status} );
-endsnippet
-snippet MPI_Buffer_detach
-MPI_Buffer_detach( ${1:void* buffer} , ${2:int* size} );
-endsnippet
-snippet MPI_File_set_size
-MPI_File_set_size( ${1:MPI_File fh} , ${2:MPI_Offset size} );
-endsnippet
-snippet MPI_Intercomm_create
-MPI_Intercomm_create( ${1:MPI_Comm local_comm} , ${2:int local_leader} , ${3:MPI_Comm bridge_comm} , ${4:int remote_leader} , ${5:int tag} , ${6:MPI_Comm* newintercomm} );
-endsnippet
-snippet MPI_File_iread_at
-MPI_File_iread_at( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:void* buf} , ${4:int count} , ${5:MPI_Datatype datatype} , ${6:MPI_Request* request} );
-endsnippet
-snippet MPI_Allreduce
-MPI_Allreduce( ${1:void* sendbuf} , ${2:void* recvbuf} , ${3:int count} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:MPI_Comm comm} );
-endsnippet
-snippet MPI_Comm_create_keyval
-MPI_Comm_create_keyval( ${1:MPI_Comm_copy_attr_function* comm_copy_attr_fn} , ${2:MPI_Comm_delete_attr_function* comm_delete_attr_fn} , ${3:int* comm_keyval} , ${4:void* extra_state} );
-endsnippet
-snippet MPI_Ibsend
-MPI_Ibsend( ${1:void* buf} , ${2:int count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
-endsnippet
-snippet MPI_File_read_all_end
-MPI_File_read_all_end( ${1:MPI_File fh} , ${2:void* buf} , ${3:MPI_Status* status} );
-endsnippet
-snippet MPI_Comm_remote_size
-MPI_Comm_remote_size( ${1:MPI_Comm comm} , ${2:int* size} );
-endsnippet
-snippet MPI_Type_contiguous
-MPI_Type_contiguous( ${1:int count} , ${2:MPI_Datatype oldtype} , ${3:MPI_Datatype* newtype} );
-endsnippet
-snippet MPI_Type_get_name
-MPI_Type_get_name( ${1:MPI_Datatype type} , ${2:char* type_name} , ${3:int* resultlen} );
-endsnippet
-snippet MPI_Reduce
-MPI_Reduce( ${1:void* sendbuf} , ${2:void* recvbuf} , ${3:int count} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:int root} , ${7:MPI_Comm comm} );
-endsnippet
-snippet MPI_Type_commit
-MPI_Type_commit( ${1:MPI_Datatype* type} );
-endsnippet
-snippet MPI_Comm_get_parent
-MPI_Comm_get_parent( ${1:MPI_Comm* parent} );
-endsnippet
-snippet MPI_Testany
-MPI_Testany( ${1:int count} , ${2:MPI_Request array_of_requests[]} , ${3:int* index} , ${4:int* flag} , ${5:MPI_Status* status} );
-endsnippet
-snippet MPI_Type_extent
-MPI_Type_extent( ${1:MPI_Datatype type} , ${2:MPI_Aint* extent} );
-endsnippet
-snippet MPI_File_preallocate
-MPI_File_preallocate( ${1:MPI_File fh} , ${2:MPI_Offset size} );
-endsnippet
-snippet MPI_File_get_position
-MPI_File_get_position( ${1:MPI_File fh} , ${2:MPI_Offset* offset} );
-endsnippet
-snippet MPI_Sendrecv_replace
-MPI_Sendrecv_replace( ${1:void* buf} , ${2:int count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int sendtag} , ${6:int source} , ${7:int recvtag} , ${8:MPI_Comm comm} , ${9:MPI_Status* status} );
-endsnippet
-snippet MPI_Type_get_extent
-MPI_Type_get_extent( ${1:MPI_Datatype type} , ${2:MPI_Aint* lb} , ${3:MPI_Aint* extent} );
-endsnippet
-snippet MPI_Keyval_create
-MPI_Keyval_create( ${1:MPI_Copy_function* copy_fn} , ${2:MPI_Delete_function* delete_fn} , ${3:int* keyval} , ${4:void* extra_state} );
-endsnippet
-snippet MPI_Mrecv
-MPI_Mrecv( ${1:void* buf} , ${2:int count} , ${3:MPI_Datatype datatype} , ${4:MPI_Message* message} , ${5:MPI_Status* status} );
-endsnippet
-snippet MPI_Type_hvector
-MPI_Type_hvector( ${1:int count} , ${2:int blocklength} , ${3:MPI_Aint stride} , ${4:MPI_Datatype oldtype} , ${5:MPI_Datatype* newtype} );
-endsnippet
-snippet MPI_Group_translate_ranks
-MPI_Group_translate_ranks( ${1:MPI_Group group1} , ${2:int n} , ${3:int ranks1[]} , ${4:MPI_Group group2} , ${5:int ranks2[]} );
-endsnippet
-snippet MPI_Testsome
-MPI_Testsome( ${1:int incount} , ${2:MPI_Request array_of_requests[]} , ${3:int* outcount} , ${4:int array_of_indices[]} , ${5:MPI_Status array_of_statuses[]} );
-endsnippet
-snippet MPI_Recv_init
-MPI_Recv_init( ${1:void* buf} , ${2:int count} , ${3:MPI_Datatype datatype} , ${4:int source} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
-endsnippet
-snippet MPI_Win_set_name
-MPI_Win_set_name( ${1:MPI_Win win} , ${2:char* win_name} );
-endsnippet
-snippet MPI_Type_dup
-MPI_Type_dup( ${1:MPI_Datatype type} , ${2:MPI_Datatype* newtype} );
-endsnippet
-snippet MPI_Query_thread
-MPI_Query_thread( ${1:int* provided} );
-endsnippet
-snippet MPI_Comm_group
-MPI_Comm_group( ${1:MPI_Comm comm} , ${2:MPI_Group* group} );
-endsnippet
 snippet MPI_Add_error_code
 MPI_Add_error_code( ${1:int errorclass} , ${2:int* errorcode} );
 endsnippet
-snippet MPI_Type_create_resized
-MPI_Type_create_resized( ${1:MPI_Datatype oldtype} , ${2:MPI_Aint lb} , ${3:MPI_Aint extent} , ${4:MPI_Datatype* newtype} );
+snippet MPI_Add_error_string
+MPI_Add_error_string( ${1:int errorcode} , ${2:const char* string} );
 endsnippet
-snippet MPI_File_seek_shared
-MPI_File_seek_shared( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:int whence} );
+snippet MPI_Aint_add
+MPI_Aint_add( ${1:MPI_Aint base} , ${2:MPI_Aint disp} );
 endsnippet
-snippet MPI_Unpublish_name
-MPI_Unpublish_name( ${1:char* service_name} , ${2:MPI_Info info} , ${3:char* port_name} );
-endsnippet
-snippet MPI_Get_address
-MPI_Get_address( ${1:void* location} , ${2:MPI_Aint* address} );
-endsnippet
-snippet MPI_Is_thread_main
-MPI_Is_thread_main( ${1:int* flag} );
-endsnippet
-snippet MPI_Irecv
-MPI_Irecv( ${1:void* buf} , ${2:int count} , ${3:MPI_Datatype datatype} , ${4:int source} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
-endsnippet
-snippet MPI_Type_create_indexed_block
-MPI_Type_create_indexed_block( ${1:int count} , ${2:int blocklength} , ${3:int array_of_displacements[]} , ${4:MPI_Datatype oldtype} , ${5:MPI_Datatype* newtype} );
-endsnippet
-snippet MPI_Initialized
-MPI_Initialized( ${1:int* flag} );
-endsnippet
-snippet MPI_File_iwrite
-MPI_File_iwrite( ${1:MPI_File fh} , ${2:void* buf} , ${3:int count} , ${4:MPI_Datatype datatype} , ${5:MPI_Request* request} );
-endsnippet
-snippet MPI_Bsend
-MPI_Bsend( ${1:void* buf} , ${2:int count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} );
-endsnippet
-snippet MPI_Group_excl
-MPI_Group_excl( ${1:MPI_Group group} , ${2:int n} , ${3:int ranks[]} , ${4:MPI_Group* newgroup} );
-endsnippet
-snippet MPI_Get_count
-MPI_Get_count( ${1:MPI_Status* status} , ${2:MPI_Datatype datatype} , ${3:int* count} );
-endsnippet
-snippet MPI_Error_string
-MPI_Error_string( ${1:int errorcode} , ${2:char* string} , ${3:int* resultlen} );
-endsnippet
-snippet MPI_Grequest_start
-MPI_Grequest_start( ${1:MPI_Grequest_query_function* query_fn} , ${2:MPI_Grequest_free_function* free_fn} , ${3:MPI_Grequest_cancel_function* cancel_fn} , ${4:void* extra_state} , ${5:MPI_Request* request} );
-endsnippet
-snippet MPI_Cartdim_get
-MPI_Cartdim_get( ${1:MPI_Comm comm} , ${2:int* ndims} );
+snippet MPI_Aint_diff
+MPI_Aint_diff( ${1:MPI_Aint addr1} , ${2:MPI_Aint addr2} );
 endsnippet
 snippet MPI_Allgather
-MPI_Allgather( ${1:void* sendbuf} , ${2:int sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:int recvcount} , ${6:MPI_Datatype recvtype} , ${7:MPI_Comm comm} );
+MPI_Allgather( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:MPI_Count recvcount} , ${6:MPI_Datatype recvtype} , ${7:MPI_Comm comm} );
 endsnippet
-snippet MPI_Cart_coords
-MPI_Cart_coords( ${1:MPI_Comm comm} , ${2:int rank} , ${3:int maxdims} , ${4:int coords[]} );
-endsnippet
-snippet MPI_Scatterv
-MPI_Scatterv( ${1:void* sendbuf} , ${2:int sendcounts[]} , ${3:int displs[]} , ${4:MPI_Datatype sendtype} , ${5:void* recvbuf} , ${6:int recvcount} , ${7:MPI_Datatype recvtype} , ${8:int root} , ${9:MPI_Comm comm} );
-endsnippet
-snippet MPI_Issend
-MPI_Issend( ${1:void* buf} , ${2:int count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
-endsnippet
-snippet MPI_File_sync
-MPI_File_sync( ${1:MPI_File fh} );
-endsnippet
-snippet MPI_Rsend
-MPI_Rsend( ${1:void* ibuf} , ${2:int count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} );
-endsnippet
-snippet MPI_File_get_amode
-MPI_File_get_amode( ${1:MPI_File fh} , ${2:int* amode} );
-endsnippet
-snippet MPI_Abort
-MPI_Abort( ${1:MPI_Comm comm} , ${2:int errorcode} );
-endsnippet
-snippet MPI_Grequest_complete
-MPI_Grequest_complete( ${1:MPI_Request request} );
-endsnippet
-snippet MPI_Pack
-MPI_Pack( ${1:void* inbuf} , ${2:int incount} , ${3:MPI_Datatype datatype} , ${4:void* outbuf} , ${5:int outsize} , ${6:int* position} , ${7:MPI_Comm comm} );
-endsnippet
-snippet MPI_Win_set_attr
-MPI_Win_set_attr( ${1:MPI_Win win} , ${2:int win_keyval} , ${3:void* attribute_val} );
-endsnippet
-snippet MPI_Info_create
-MPI_Info_create( ${1:MPI_Info* info} );
-endsnippet
-snippet MPI_File_open
-MPI_File_open( ${1:MPI_Comm comm} , ${2:char* filename} , ${3:int amode} , ${4:MPI_Info info} , ${5:MPI_File* fh} );
-endsnippet
-snippet MPI_Gatherv
-MPI_Gatherv( ${1:void* sendbuf} , ${2:int sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:int recvcounts[]} , ${6:int displs[]} , ${7:MPI_Datatype recvtype} , ${8:int root} , ${9:MPI_Comm comm} );
-endsnippet
-snippet MPI_Type_get_attr
-MPI_Type_get_attr( ${1:MPI_Datatype type} , ${2:int type_keyval} , ${3:void* attribute_val} , ${4:int* flag} );
-endsnippet
-snippet MPI_Comm_set_name
-MPI_Comm_set_name( ${1:MPI_Comm comm} , ${2:char* comm_name} );
-endsnippet
-snippet MPI_Comm_disconnect
-MPI_Comm_disconnect( ${1:MPI_Comm* comm} );
-endsnippet
-snippet MPI_Comm_remote_group
-MPI_Comm_remote_group( ${1:MPI_Comm comm} , ${2:MPI_Group* group} );
-endsnippet
-snippet MPI_Cart_shift
-MPI_Cart_shift( ${1:MPI_Comm comm} , ${2:int direction} , ${3:int disp} , ${4:int* rank_source} , ${5:int* rank_dest} );
-endsnippet
-snippet MPI_Init_thread
-MPI_Init_thread( ${1:int* argc} , ${2:char*** argv} , ${3:int req} , ${4:int* provided} );
-endsnippet
-snippet MPI_Comm_size
-MPI_Comm_size( ${1:MPI_Comm comm} , ${2:int* size} );
-endsnippet
-snippet MPI_Type_get_envelope
-MPI_Type_get_envelope( ${1:MPI_Datatype type} , ${2:int* num_integers} , ${3:int* num_addresses} , ${4:int* num_datatypes} , ${5:int* combiner} );
-endsnippet
-snippet MPI_File_iread_shared
-MPI_File_iread_shared( ${1:MPI_File fh} , ${2:void* buf} , ${3:int count} , ${4:MPI_Datatype datatype} , ${5:MPI_Request* request} );
-endsnippet
-snippet MPI_File_set_errhandler
-MPI_File_set_errhandler( ${1:MPI_File file} , ${2:MPI_Errhandler errhandler} );
-endsnippet
-snippet MPI_Register_datarep
-MPI_Register_datarep( ${1:char* datarep} , ${2:MPI_Datarep_conversion_function* read_conversion_fn} , ${3:MPI_Datarep_conversion_function* write_conversion_fn} , ${4:MPI_Datarep_extent_function* dtype_file_extent_fn} , ${5:void* extra_state} );
-endsnippet
-snippet MPI_File_read_ordered
-MPI_File_read_ordered( ${1:MPI_File fh} , ${2:void* buf} , ${3:int count} , ${4:MPI_Datatype datatype} , ${5:MPI_Status* status} );
-endsnippet
-snippet MPI_Init
-MPI_Init( ${1:int* argc} , ${2:char *** argv} );
-endsnippet
-snippet MPI_Waitsome
-MPI_Waitsome( ${1:int incount} , ${2:MPI_Request array_of_requests[]} , ${3:int* outcount} , ${4:int array_of_indices[]} , ${5:MPI_Status array_of_statuses[]} );
-endsnippet
-snippet MPI_Group_difference
-MPI_Group_difference( ${1:MPI_Group group1} , ${2:MPI_Group group2} , ${3:MPI_Group* newgroup} );
-endsnippet
-snippet MPI_Attr_get
-MPI_Attr_get( ${1:MPI_Comm comm} , ${2:int keyval} , ${3:void* attribute_val} , ${4:int* flag} );
-endsnippet
-snippet MPI_Reduce_scatter
-MPI_Reduce_scatter( ${1:void* sendbuf} , ${2:void* recvbuf} , ${3:int recvcounts[]} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:MPI_Comm comm} );
-endsnippet
-snippet MPI_Group_incl
-MPI_Group_incl( ${1:MPI_Group group} , ${2:int n} , ${3:int ranks[]} , ${4:MPI_Group* newgroup} );
-endsnippet
-snippet MPI_Imrecv
-MPI_Imrecv( ${1:void* buf} , ${2:int count} , ${3:MPI_Datatype datatype} , ${4:MPI_Message* message} , ${5:MPI_Request* status} );
-endsnippet
-snippet MPI_Wait
-MPI_Wait( ${1:MPI_Request* request} , ${2:MPI_Status* status} );
-endsnippet
-snippet MPI_Testall
-MPI_Testall( ${1:int count} , ${2:MPI_Request array_of_requests[]} , ${3:int* flag} , ${4:MPI_Status array_of_statuses[]} );
-endsnippet
-snippet MPI_File_set_info
-MPI_File_set_info( ${1:MPI_File fh} , ${2:MPI_Info info} );
-endsnippet
-snippet MPI_Irsend
-MPI_Irsend( ${1:void* buf} , ${2:int count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
-endsnippet
-snippet MPI_Get_version
-MPI_Get_version( ${1:int* version} , ${2:int* subversion} );
-endsnippet
-snippet MPI_Comm_create_errhandler
-MPI_Comm_create_errhandler( ${1:MPI_Comm_errhandler_function* function} , ${2:MPI_Errhandler* errhandler} );
-endsnippet
-snippet MPI_File_write_all
-MPI_File_write_all( ${1:MPI_File fh} , ${2:void* buf} , ${3:int count} , ${4:MPI_Datatype datatype} , ${5:MPI_Status* status} );
-endsnippet
-snippet MPI_Comm_connect
-MPI_Comm_connect( ${1:char* port_name} , ${2:MPI_Info info} , ${3:int root} , ${4:MPI_Comm comm} , ${5:MPI_Comm* newcomm} );
-endsnippet
-snippet MPI_Group_compare
-MPI_Group_compare( ${1:MPI_Group group1} , ${2:MPI_Group group2} , ${3:int* result} );
-endsnippet
-snippet MPI_Address
-MPI_Address( ${1:void* location} , ${2:MPI_Aint* address} );
-endsnippet
-snippet MPI_Comm_compare
-MPI_Comm_compare( ${1:MPI_Comm comm1} , ${2:MPI_Comm comm2} , ${3:int* result} );
-endsnippet
-snippet MPI_Win_unlock
-MPI_Win_unlock( ${1:int rank} , ${2:MPI_Win win} );
-endsnippet
-snippet MPI_Pack_external
-MPI_Pack_external( ${1:char* datarep} , ${2:void* inbuf} , ${3:int incount} , ${4:MPI_Datatype datatype} , ${5:void* outbuf} , ${6:MPI_Aint outsize} , ${7:MPI_Aint* position} );
-endsnippet
-snippet MPI_Request_free
-MPI_Request_free( ${1:MPI_Request* request} );
-endsnippet
-snippet MPI_Topo_test
-MPI_Topo_test( ${1:MPI_Comm comm} , ${2:int* status} );
-endsnippet
-snippet MPI_File_read
-MPI_File_read( ${1:MPI_File fh} , ${2:void* buf} , ${3:int count} , ${4:MPI_Datatype datatype} , ${5:MPI_Status* status} );
-endsnippet
-snippet MPI_Buffer_attach
-MPI_Buffer_attach( ${1:void* buffer} , ${2:int size} );
-endsnippet
-snippet MPI_Win_call_errhandler
-MPI_Win_call_errhandler( ${1:MPI_Win win} , ${2:int errorcode} );
-endsnippet
-snippet MPI_Win_get_group
-MPI_Win_get_group( ${1:MPI_Win win} , ${2:MPI_Group* group} );
-endsnippet
-snippet MPI_Errhandler_create
-MPI_Errhandler_create( ${1:MPI_Handler_function* function} , ${2:MPI_Errhandler* errhandler} );
-endsnippet
-snippet MPI_Cart_create
-MPI_Cart_create( ${1:MPI_Comm old_comm} , ${2:int ndims} , ${3:int dims[]} , ${4:int periods[]} , ${5:int reorder} , ${6:MPI_Comm* comm_cart} );
-endsnippet
-snippet MPI_Status_set_cancelled
-MPI_Status_set_cancelled( ${1:MPI_Status* status} , ${2:int flag} );
-endsnippet
-snippet MPI_Win_get_attr
-MPI_Win_get_attr( ${1:MPI_Win win} , ${2:int win_keyval} , ${3:void* attribute_val} , ${4:int* flag} );
-endsnippet
-snippet MPI_Type_struct
-MPI_Type_struct( ${1:int count} , ${2:int array_of_blocklengths[]} , ${3:MPI_Aint array_of_displacements[]} , ${4:MPI_Datatype array_of_types[]} , ${5:MPI_Datatype* newtype} );
-endsnippet
-snippet MPI_Graph_neighbors_count
-MPI_Graph_neighbors_count( ${1:MPI_Comm comm} , ${2:int rank} , ${3:int* nneighbors} );
-endsnippet
-snippet MPI_File_get_view
-MPI_File_get_view( ${1:MPI_File fh} , ${2:MPI_Offset* disp} , ${3:MPI_Datatype* etype} , ${4:MPI_Datatype* filetype} , ${5:char* datarep} );
+snippet MPI_Allgather_init
+MPI_Allgather_init( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:MPI_Count recvcount} , ${6:MPI_Datatype recvtype} , ${7:MPI_Comm comm} , ${8:MPI_Info info} , ${9:MPI_Request* request} );
 endsnippet
 snippet MPI_Allgatherv
-MPI_Allgatherv( ${1:void* sendbuf} , ${2:int sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:int recvcounts[]} , ${6:int displs[]} , ${7:MPI_Datatype recvtype} , ${8:MPI_Comm comm} );
+MPI_Allgatherv( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:const MPI_Count recvcounts[]} , ${6:const MPI_Aint displs[]} , ${7:MPI_Datatype recvtype} , ${8:MPI_Comm comm} );
 endsnippet
-snippet MPI_Sendrecv
-MPI_Sendrecv( ${1:void* sendbuf} , ${2:int sendcount} , ${3:MPI_Datatype sendtype} , ${4:int dest} , ${5:int sendtag} , ${6:void* recvbuf} , ${7:int recvcount} , ${8:MPI_Datatype recvtype} , ${9:int source} , ${10:int recvtag} , ${11:MPI_Comm comm} , ${12:MPI_Status* status} );
-endsnippet
-snippet MPI_File_get_position_shared
-MPI_File_get_position_shared( ${1:MPI_File fh} , ${2:MPI_Offset* offset} );
-endsnippet
-snippet MPI_Graph_neighbors
-MPI_Graph_neighbors( ${1:MPI_Comm comm} , ${2:int rank} , ${3:int maxneighbors} , ${4:int neighbors[]} );
-endsnippet
-snippet MPI_Dims_create
-MPI_Dims_create( ${1:int nnodes} , ${2:int ndims} , ${3:int dims[]} );
-endsnippet
-snippet MPI_File_iread
-MPI_File_iread( ${1:MPI_File fh} , ${2:void* buf} , ${3:int count} , ${4:MPI_Datatype datatype} , ${5:MPI_Request* request} );
-endsnippet
-snippet MPI_Scatter
-MPI_Scatter( ${1:void* sendbuf} , ${2:int sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:int recvcount} , ${6:MPI_Datatype recvtype} , ${7:int root} , ${8:MPI_Comm comm} );
-endsnippet
-snippet MPI_File_get_byte_offset
-MPI_File_get_byte_offset( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:MPI_Offset* disp} );
-endsnippet
-snippet MPI_Comm_free_keyval
-MPI_Comm_free_keyval( ${1:int* comm_keyval} );
-endsnippet
-snippet MPI_Op_create
-MPI_Op_create( ${1:MPI_User_function* function} , ${2:int commute} , ${3:MPI_Op* op} );
-endsnippet
-snippet MPI_File_seek
-MPI_File_seek( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:int whence} );
-endsnippet
-snippet MPI_Add_error_string
-MPI_Add_error_string( ${1:int errorcode} , ${2:char* string} );
-endsnippet
-snippet MPI_Mprobe
-MPI_Mprobe( ${1:int source} , ${2:int tag} , ${3:MPI_Comm comm} , ${4:MPI_Message* message} , ${5:MPI_Status* status} );
-endsnippet
-snippet MPI_Ssend_init
-MPI_Ssend_init( ${1:void* buf} , ${2:int count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
-endsnippet
-snippet MPI_Rsend_init
-MPI_Rsend_init( ${1:void* buf} , ${2:int count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
-endsnippet
-snippet MPI_Info_free
-MPI_Info_free( ${1:MPI_Info* info} );
-endsnippet
-snippet MPI_Publish_name
-MPI_Publish_name( ${1:char* service_name} , ${2:MPI_Info info} , ${3:char* port_name} );
-endsnippet
-snippet MPI_Bcast
-MPI_Bcast( ${1:void* buffer} , ${2:int count} , ${3:MPI_Datatype datatype} , ${4:int root} , ${5:MPI_Comm comm} );
-endsnippet
-snippet MPI_Get_processor_name
-MPI_Get_processor_name( ${1:char* name} , ${2:int* resultlen} );
-endsnippet
-snippet MPI_Info_set
-MPI_Info_set( ${1:MPI_Info info} , ${2:char* key} , ${3:char* value} );
-endsnippet
-snippet MPI_File_write_ordered_end
-MPI_File_write_ordered_end( ${1:MPI_File fh} , ${2:void* buf} , ${3:MPI_Status* status} );
-endsnippet
-snippet MPI_Graph_create
-MPI_Graph_create( ${1:MPI_Comm comm} , ${2:int nnodes} , ${3:int index[]} , ${4:int edges[]} , ${5:int reorder} , ${6:MPI_Comm* comm_graph} );
-endsnippet
-snippet MPI_Comm_free
-MPI_Comm_free( ${1:MPI_Comm* comm} );
-endsnippet
-snippet MPI_File_write_at_all
-MPI_File_write_at_all( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:void* buf} , ${4:int count} , ${5:MPI_Datatype datatype} , ${6:MPI_Status* status} );
-endsnippet
-snippet MPI_Errhandler_get
-MPI_Errhandler_get( ${1:MPI_Comm comm} , ${2:MPI_Errhandler* errhandler} );
-endsnippet
-snippet MPI_Pack_size
-MPI_Pack_size( ${1:int incount} , ${2:MPI_Datatype datatype} , ${3:MPI_Comm comm} , ${4:int* size} );
-endsnippet
-snippet MPI_Comm_call_errhandler
-MPI_Comm_call_errhandler( ${1:MPI_Comm comm} , ${2:int errorcode} );
-endsnippet
-snippet MPI_Comm_test_inter
-MPI_Comm_test_inter( ${1:MPI_Comm comm} , ${2:int* flag} );
-endsnippet
-snippet MPI_Intercomm_merge
-MPI_Intercomm_merge( ${1:MPI_Comm intercomm} , ${2:int high} , ${3:MPI_Comm* newintercomm} );
-endsnippet
-snippet MPI_Win_complete
-MPI_Win_complete( ${1:MPI_Win win} );
-endsnippet
-snippet MPI_File_get_type_extent
-MPI_File_get_type_extent( ${1:MPI_File fh} , ${2:MPI_Datatype datatype} , ${3:MPI_Aint* extent} );
-endsnippet
-snippet MPI_Graph_map
-MPI_Graph_map( ${1:MPI_Comm comm} , ${2:int nnodes} , ${3:int index[]} , ${4:int edges[]} , ${5:int* newrank} );
-endsnippet
-snippet MPI_File_read_all_begin
-MPI_File_read_all_begin( ${1:MPI_File fh} , ${2:void* buf} , ${3:int count} , ${4:MPI_Datatype datatype} );
-endsnippet
-snippet MPI_Info_get_valuelen
-MPI_Info_get_valuelen( ${1:MPI_Info info} , ${2:char* key} , ${3:int* valuelen} , ${4:int* flag} );
-endsnippet
-snippet MPI_Put
-MPI_Put( ${1:void* origin_addr} , ${2:int origin_count} , ${3:MPI_Datatype origin_datatype} , ${4:int target_rank} , ${5:MPI_Aint target_disp} , ${6:int target_count} , ${7:MPI_Datatype target_datatype} , ${8:MPI_Win win} );
-endsnippet
-snippet MPI_File_read_at_all
-MPI_File_read_at_all( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:void* buf} , ${4:int count} , ${5:MPI_Datatype datatype} , ${6:MPI_Status* status} );
-endsnippet
-snippet MPI_File_read_ordered_end
-MPI_File_read_ordered_end( ${1:MPI_File fh} , ${2:void* buf} , ${3:MPI_Status* status} );
-endsnippet
-snippet MPI_Isend
-MPI_Isend( ${1:void* buf} , ${2:int count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
-endsnippet
-snippet MPI_Type_set_attr
-MPI_Type_set_attr( ${1:MPI_Datatype type} , ${2:int type_keyval} , ${3:void* attr_val} );
-endsnippet
-snippet MPI_Group_rank
-MPI_Group_rank( ${1:MPI_Group group} , ${2:int* rank} );
-endsnippet
-snippet MPI_Alltoall
-MPI_Alltoall( ${1:void* sendbuf} , ${2:int sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:int recvcount} , ${6:MPI_Datatype recvtype} , ${7:MPI_Comm comm} );
-endsnippet
-snippet MPI_File_create_errhandler
-MPI_File_create_errhandler( ${1:MPI_File_errhandler_function* function} , ${2:MPI_Errhandler* errhandler} );
-endsnippet
-snippet MPI_Info_get
-MPI_Info_get( ${1:MPI_Info info} , ${2:char* key} , ${3:int valuelen} , ${4:char* value} , ${5:int* flag} );
-endsnippet
-snippet MPI_File_iwrite_at
-MPI_File_iwrite_at( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:void* buf} , ${4:int count} , ${5:MPI_Datatype datatype} , ${6:MPI_Request* request} );
-endsnippet
-snippet MPI_Group_intersection
-MPI_Group_intersection( ${1:MPI_Group group1} , ${2:MPI_Group group2} , ${3:MPI_Group* newgroup} );
-endsnippet
-snippet MPI_Type_free_keyval
-MPI_Type_free_keyval( ${1:int* type_keyval} );
-endsnippet
-snippet MPI_Type_create_struct
-MPI_Type_create_struct( ${1:int count} , ${2:int array_of_block_lengths[]} , ${3:MPI_Aint array_of_displacements[]} , ${4:MPI_Datatype array_of_types[]} , ${5:MPI_Datatype* newtype} );
-endsnippet
-snippet MPI_Type_get_contents
-MPI_Type_get_contents( ${1:MPI_Datatype mtype} , ${2:int max_integers} , ${3:int max_addresses} , ${4:int max_datatypes} , ${5:int array_of_integers[]} , ${6:MPI_Aint array_of_addresses[]} , ${7:MPI_Datatype array_of_datatypes[]} );
-endsnippet
-snippet MPI_Reduce_local
-MPI_Reduce_local( ${1:void* inbuf} , ${2:void* inoutbuf} , ${3:int count} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} );
-endsnippet
-snippet MPI_Group_union
-MPI_Group_union( ${1:MPI_Group group1} , ${2:MPI_Group group2} , ${3:MPI_Group* newgroup} );
-endsnippet
-snippet MPI_Type_free
-MPI_Type_free( ${1:MPI_Datatype* type} );
-endsnippet
-snippet MPI_Info_get_nthkey
-MPI_Info_get_nthkey( ${1:MPI_Info info} , ${2:int n} , ${3:char* key} );
-endsnippet
-snippet MPI_Win_get_name
-MPI_Win_get_name( ${1:MPI_Win win} , ${2:char* win_name} , ${3:int* resultlen} );
-endsnippet
-snippet MPI_File_write_at_all_begin
-MPI_File_write_at_all_begin( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:void* buf} , ${4:int count} , ${5:MPI_Datatype datatype} );
-endsnippet
-snippet MPI_Unpack_external
-MPI_Unpack_external( ${1:char* datarep} , ${2:void* inbuf} , ${3:MPI_Aint insize} , ${4:MPI_Aint* position} , ${5:void* outbuf} , ${6:int outcount} , ${7:MPI_Datatype datatype} );
-endsnippet
-snippet MPI_Errhandler_set
-MPI_Errhandler_set( ${1:MPI_Comm comm} , ${2:MPI_Errhandler errhandler} );
-endsnippet
-snippet MPI_File_read_at_all_begin
-MPI_File_read_at_all_begin( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:void* buf} , ${4:int count} , ${5:MPI_Datatype datatype} );
-endsnippet
-snippet MPI_Comm_get_errhandler
-MPI_Comm_get_errhandler( ${1:MPI_Comm comm} , ${2:MPI_Errhandler* erhandler} );
-endsnippet
-snippet MPI_Test_cancelled
-MPI_Test_cancelled( ${1:MPI_Status* status} , ${2:int* flag} );
-endsnippet
-snippet MPI_Win_lock
-MPI_Win_lock( ${1:int lock_type} , ${2:int rank} , ${3:int assert} , ${4:MPI_Win win} );
-endsnippet
-snippet MPI_Win_create
-MPI_Win_create( ${1:void* base} , ${2:MPI_Aint size} , ${3:int disp_unit} , ${4:MPI_Info info} , ${5:MPI_Comm comm} , ${6:MPI_Win* win} );
-endsnippet
-snippet MPI_Test
-MPI_Test( ${1:MPI_Request* request} , ${2:int* flag} , ${3:MPI_Status* status} );
-endsnippet
-snippet MPI_Type_create_hvector
-MPI_Type_create_hvector( ${1:int count} , ${2:int blocklength} , ${3:MPI_Aint stride} , ${4:MPI_Datatype oldtype} , ${5:MPI_Datatype* newtype} );
-endsnippet
-snippet MPI_File_write_all_end
-MPI_File_write_all_end( ${1:MPI_File fh} , ${2:void* buf} , ${3:MPI_Status* status} );
-endsnippet
-snippet MPI_Info_get_nkeys
-MPI_Info_get_nkeys( ${1:MPI_Info info} , ${2:int* nkeys} );
-endsnippet
-snippet MPI_Win_start
-MPI_Win_start( ${1:MPI_Group group} , ${2:int assert} , ${3:MPI_Win win} );
-endsnippet
-snippet MPI_File_get_size
-MPI_File_get_size( ${1:MPI_File fh} , ${2:MPI_Offset* size} );
-endsnippet
-snippet MPI_Finalized
-MPI_Finalized( ${1:int* flag} );
-endsnippet
-snippet MPI_Win_free_keyval
-MPI_Win_free_keyval( ${1:int* win_keyval} );
-endsnippet
-snippet MPI_Waitany
-MPI_Waitany( ${1:int count} , ${2:MPI_Request array_of_requests[]} , ${3:int* index} , ${4:MPI_Status* status} );
-endsnippet
-snippet MPI_Open_port
-MPI_Open_port( ${1:MPI_Info info} , ${2:char* port_name} );
-endsnippet
-snippet MPI_Type_indexed
-MPI_Type_indexed( ${1:int count} , ${2:int array_of_blocklengths[]} , ${3:int array_of_displacements[]} , ${4:MPI_Datatype oldtype} , ${5:MPI_Datatype* newtype} );
-endsnippet
-snippet MPI_Send_init
-MPI_Send_init( ${1:void* buf} , ${2:int count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
-endsnippet
-snippet MPI_Gather
-MPI_Gather( ${1:void* sendbuf} , ${2:int sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:int recvcount} , ${6:MPI_Datatype recvtype} , ${7:int root} , ${8:MPI_Comm comm} );
-endsnippet
-snippet MPI_Type_vector
-MPI_Type_vector( ${1:int count} , ${2:int blocklength} , ${3:int stride} , ${4:MPI_Datatype oldtype} , ${5:MPI_Datatype* newtype} );
-endsnippet
-snippet MPI_Get_elements
-MPI_Get_elements( ${1:MPI_Status* status} , ${2:MPI_Datatype datatype} , ${3:int* count} );
-endsnippet
-snippet MPI_File_write
-MPI_File_write( ${1:MPI_File fh} , ${2:void* buf} , ${3:int count} , ${4:MPI_Datatype datatype} , ${5:MPI_Status* status} );
-endsnippet
-snippet MPI_File_read_at_all_end
-MPI_File_read_at_all_end( ${1:MPI_File fh} , ${2:void* buf} , ${3:MPI_Status* status} );
-endsnippet
-snippet MPI_Probe
-MPI_Probe( ${1:int source} , ${2:int tag} , ${3:MPI_Comm comm} , ${4:MPI_Status* status} );
-endsnippet
-snippet MPI_File_set_view
-MPI_File_set_view( ${1:MPI_File fh} , ${2:MPI_Offset disp} , ${3:MPI_Datatype etype} , ${4:MPI_Datatype filetype} , ${5:char* datarep} , ${6:MPI_Info info} );
-endsnippet
-snippet MPI_Unpack
-MPI_Unpack( ${1:void* inbuf} , ${2:int insize} , ${3:int* position} , ${4:void* outbuf} , ${5:int outcount} , ${6:MPI_Datatype datatype} , ${7:MPI_Comm comm} );
-endsnippet
-snippet MPI_Type_ub
-MPI_Type_ub( ${1:MPI_Datatype mtype} , ${2:MPI_Aint* ub} );
-endsnippet
-snippet MPI_Status_set_elements
-MPI_Status_set_elements( ${1:MPI_Status* status} , ${2:MPI_Datatype datatype} , ${3:int count} );
-endsnippet
-snippet MPI_Win_delete_attr
-MPI_Win_delete_attr( ${1:MPI_Win win} , ${2:int win_keyval} );
-endsnippet
-snippet MPI_Type_hindexed
-MPI_Type_hindexed( ${1:int count} , ${2:int array_of_blocklengths[]} , ${3:MPI_Aint array_of_displacements[]} , ${4:MPI_Datatype oldtype} , ${5:MPI_Datatype* newtype} );
-endsnippet
-snippet MPI_File_set_atomicity
-MPI_File_set_atomicity( ${1:MPI_File fh} , ${2:int flag} );
-endsnippet
-snippet MPI_Group_range_incl
-MPI_Group_range_incl( ${1:MPI_Group group} , ${2:int n} , ${3:int ranges[][3]} , ${4:MPI_Group* newgroup} );
-endsnippet
-snippet MPI_Get
-MPI_Get( ${1:void* origin_addr} , ${2:int origin_count} , ${3:MPI_Datatype origin_datatype} , ${4:int target_rank} , ${5:MPI_Aint target_disp} , ${6:int target_count} , ${7:MPI_Datatype target_datatype} , ${8:MPI_Win win} );
-endsnippet
-snippet MPI_Iprobe
-MPI_Iprobe( ${1:int source} , ${2:int tag} , ${3:MPI_Comm comm} , ${4:int* flag} , ${5:MPI_Status* status} );
-endsnippet
-snippet MPI_File_write_at_all_end
-MPI_File_write_at_all_end( ${1:MPI_File fh} , ${2:void* buf} , ${3:MPI_Status* status} );
-endsnippet
-snippet MPI_Type_get_true_extent
-MPI_Type_get_true_extent( ${1:MPI_Datatype datatype} , ${2:MPI_Aint* true_lb} , ${3:MPI_Aint* true_extent} );
-endsnippet
-snippet MPI_Graph_get
-MPI_Graph_get( ${1:MPI_Comm comm} , ${2:int maxindex} , ${3:int maxedges} , ${4:int index[]} , ${5:int edges[]} );
-endsnippet
-snippet MPI_Info_delete
-MPI_Info_delete( ${1:MPI_Info info} , ${2:char* key} );
-endsnippet
-snippet MPI_Cart_rank
-MPI_Cart_rank( ${1:MPI_Comm comm} , ${2:int coords[]} , ${3:int* rank} );
-endsnippet
-snippet MPI_Finalize
-MPI_Finalize();
-endsnippet
-snippet MPI_Comm_create
-MPI_Comm_create( ${1:MPI_Comm comm} , ${2:MPI_Group group} , ${3:MPI_Comm* newcomm} );
-endsnippet
-snippet MPI_Pack_external_size
-MPI_Pack_external_size( ${1:char* datarep} , ${2:int incount} , ${3:MPI_Datatype datatype} , ${4:MPI_Aint* size} );
-endsnippet
-snippet MPI_Comm_join
-MPI_Comm_join( ${1:int fd} , ${2:MPI_Comm* intercomm} );
-endsnippet
-snippet MPI_File_read_at
-MPI_File_read_at( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:void* buf} , ${4:int count} , ${5:MPI_Datatype datatype} , ${6:MPI_Status* status} );
-endsnippet
-snippet MPI_Keyval_free
-MPI_Keyval_free( ${1:int* keyval} );
-endsnippet
-snippet MPI_Win_wait
-MPI_Win_wait( ${1:MPI_Win win} );
+snippet MPI_Allgatherv_init
+MPI_Allgatherv_init( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:const MPI_Count recvcounts[]} , ${6:const MPI_Aint displs[]} , ${7:MPI_Datatype recvtype} , ${8:MPI_Comm comm} , ${9:MPI_Info info} , ${10:MPI_Request* request} );
 endsnippet
 snippet MPI_Alloc_mem
 MPI_Alloc_mem( ${1:MPI_Aint size} , ${2:MPI_Info info} , ${3:void* baseptr} );
 endsnippet
-snippet MPI_Improbe
-MPI_Improbe( ${1:int source} , ${2:int tag} , ${3:MPI_Comm comm} , ${4:int* flag} , ${5:MPI_Message* message} , ${6:MPI_Status* status} );
+snippet MPI_Allreduce
+MPI_Allreduce( ${1:const void* sendbuf} , ${2:void* recvbuf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:MPI_Comm comm} );
 endsnippet
-snippet MPI_Type_size
-MPI_Type_size( ${1:MPI_Datatype type} , ${2:int* size} );
+snippet MPI_Allreduce_init
+MPI_Allreduce_init( ${1:const void* sendbuf} , ${2:void* recvbuf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:MPI_Comm comm} , ${7:MPI_Info info} , ${8:MPI_Request* request} );
 endsnippet
-snippet MPI_Lookup_name
-MPI_Lookup_name( ${1:char* service_name} , ${2:MPI_Info info} , ${3:char* port_name} );
+snippet MPI_Alltoall
+MPI_Alltoall( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:MPI_Count recvcount} , ${6:MPI_Datatype recvtype} , ${7:MPI_Comm comm} );
 endsnippet
-snippet MPI_File_get_atomicity
-MPI_File_get_atomicity( ${1:MPI_File fh} , ${2:int* flag} );
+snippet MPI_Alltoall_init
+MPI_Alltoall_init( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:MPI_Count recvcount} , ${6:MPI_Datatype recvtype} , ${7:MPI_Comm comm} , ${8:MPI_Info info} , ${9:MPI_Request* request} );
 endsnippet
-snippet MPI_File_read_shared
-MPI_File_read_shared( ${1:MPI_File fh} , ${2:void* buf} , ${3:int count} , ${4:MPI_Datatype datatype} , ${5:MPI_Status* status} );
+snippet MPI_Alltoallv
+MPI_Alltoallv( ${1:const void* sendbuf} , ${2:const MPI_Count sendcounts[]} , ${3:const MPI_Aint sdispls[]} , ${4:MPI_Datatype sendtype} , ${5:void* recvbuf} , ${6:const MPI_Count recvcounts[]} , ${7:const MPI_Aint rdispls[]} , ${8:MPI_Datatype recvtype} , ${9:MPI_Comm comm} );
 endsnippet
-snippet MPI_Type_create_darray
-MPI_Type_create_darray( ${1:int size} , ${2:int rank} , ${3:int ndims} , ${4:int gsize_array[]} , ${5:int distrib_array[]} , ${6:int darg_array[]} , ${7:int psize_array[]} , ${8:int order} , ${9:MPI_Datatype oldtype} , ${10:MPI_Datatype* newtype} );
+snippet MPI_Alltoallv_init
+MPI_Alltoallv_init( ${1:const void* sendbuf} , ${2:const MPI_Count sendcounts[]} , ${3:const MPI_Aint sdispls[]} , ${4:MPI_Datatype sendtype} , ${5:void* recvbuf} , ${6:const MPI_Count recvcounts[]} , ${7:const MPI_Aint rdispls[]} , ${8:MPI_Datatype recvtype} , ${9:MPI_Comm comm} , ${10:MPI_Info info} , ${11:MPI_Request* request} );
 endsnippet
-snippet MPI_Win_create_errhandler
-MPI_Win_create_errhandler( ${1:MPI_Win_errhandler_function* function} , ${2:MPI_Errhandler* errhandler} );
+snippet MPI_Alltoallw
+MPI_Alltoallw( ${1:const void* sendbuf} , ${2:const MPI_Count sendcounts[]} , ${3:const MPI_Aint sdispls[]} , ${4:const MPI_Datatype sendtypes[]} , ${5:void* recvbuf} , ${6:const MPI_Count recvcounts[]} , ${7:const MPI_Aint rdispls[]} , ${8:const MPI_Datatype recvtypes[]} , ${9:MPI_Comm comm} );
 endsnippet
-snippet MPI_Cart_map
-MPI_Cart_map( ${1:MPI_Comm comm} , ${2:int ndims} , ${3:int dims[]} , ${4:int periods[]} , ${5:int* newrank} );
+snippet MPI_Alltoallw_init
+MPI_Alltoallw_init( ${1:const void* sendbuf} , ${2:const MPI_Count sendcounts[]} , ${3:const MPI_Aint sdispls[]} , ${4:const MPI_Datatype sendtypes[]} , ${5:void* recvbuf} , ${6:const MPI_Count recvcounts[]} , ${7:const MPI_Aint rdispls[]} , ${8:const MPI_Datatype recvtypes[]} , ${9:MPI_Comm comm} , ${10:MPI_Info info} , ${11:MPI_Request* request} );
 endsnippet
-snippet MPI_File_write_at
-MPI_File_write_at( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:void* buf} , ${4:int count} , ${5:MPI_Datatype datatype} , ${6:MPI_Status* status} );
+snippet MPI_Attr_delete
+MPI_Attr_delete( ${1:MPI_Comm comm} , ${2:int keyval} );
 endsnippet
-snippet MPI_Comm_accept
-MPI_Comm_accept( ${1:char* port_name} , ${2:MPI_Info info} , ${3:int root} , ${4:MPI_Comm comm} , ${5:MPI_Comm* newcomm} );
-endsnippet
-snippet MPI_Type_set_name
-MPI_Type_set_name( ${1:MPI_Datatype type} , ${2:char* type_name} );
-endsnippet
-snippet MPI_Close_port
-MPI_Close_port( ${1:char* port_name} );
-endsnippet
-snippet MPI_File_close
-MPI_File_close( ${1:MPI_File* fh} );
-endsnippet
-snippet MPI_Type_create_subarray
-MPI_Type_create_subarray( ${1:int ndims} , ${2:int size_array[]} , ${3:int subsize_array[]} , ${4:int start_array[]} , ${5:int order} , ${6:MPI_Datatype oldtype} , ${7:MPI_Datatype* newtype} );
-endsnippet
-snippet MPI_File_delete
-MPI_File_delete( ${1:char* filename} , ${2:MPI_Info info} );
-endsnippet
-snippet MPI_Comm_set_attr
-MPI_Comm_set_attr( ${1:MPI_Comm comm} , ${2:int comm_keyval} , ${3:void* attribute_val} );
-endsnippet
-snippet MPI_File_read_all
-MPI_File_read_all( ${1:MPI_File fh} , ${2:void* buf} , ${3:int count} , ${4:MPI_Datatype datatype} , ${5:MPI_Status* status} );
-endsnippet
-snippet MPI_Recv
-MPI_Recv( ${1:void* buf} , ${2:int count} , ${3:MPI_Datatype datatype} , ${4:int source} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Status* status} );
-endsnippet
-snippet MPI_Comm_dup
-MPI_Comm_dup( ${1:MPI_Comm comm} , ${2:MPI_Comm* newcomm} );
-endsnippet
-snippet MPI_Waitall
-MPI_Waitall( ${1:int count} , ${2:MPI_Request array_of_requests[]} , ${3:MPI_Status array_of_statuses[]} );
-endsnippet
-snippet MPI_Comm_delete_attr
-MPI_Comm_delete_attr( ${1:MPI_Comm comm} , ${2:int comm_keyval} );
-endsnippet
-snippet MPI_Ssend
-MPI_Ssend( ${1:void* buf} , ${2:int count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} );
-endsnippet
-snippet MPI_Group_size
-MPI_Group_size( ${1:MPI_Group group} , ${2:int* size} );
-endsnippet
-snippet MPI_File_get_errhandler
-MPI_File_get_errhandler( ${1:MPI_File file} , ${2:MPI_Errhandler* errhandler} );
+snippet MPI_Attr_get
+MPI_Attr_get( ${1:MPI_Comm comm} , ${2:int keyval} , ${3:void* attribute_val} , ${4:int* flag} );
 endsnippet
 snippet MPI_Attr_put
 MPI_Attr_put( ${1:MPI_Comm comm} , ${2:int keyval} , ${3:void* attribute_val} );
@@ -754,92 +70,1286 @@ endsnippet
 snippet MPI_Barrier
 MPI_Barrier( ${1:MPI_Comm comm} );
 endsnippet
-snippet MPI_Win_free
-MPI_Win_free( ${1:MPI_Win* win} );
+snippet MPI_Barrier_init
+MPI_Barrier_init( ${1:MPI_Comm comm} , ${2:MPI_Info info} , ${3:MPI_Request* request} );
 endsnippet
-snippet MPI_Alltoallw
-MPI_Alltoallw( ${1:void* sendbuf} , ${2:int sendcounts[]} , ${3:int sdispls[]} , ${4:MPI_Datatype sendtypes[]} , ${5:void* recvbuf} , ${6:int recvcounts[]} , ${7:int rdispls[]} , ${8:MPI_Datatype recvtypes[]} , ${9:MPI_Comm comm} );
+snippet MPI_Bcast
+MPI_Bcast( ${1:void* buffer} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int root} , ${5:MPI_Comm comm} );
 endsnippet
-snippet MPI_Alltoallv
-MPI_Alltoallv( ${1:void* sendbuf} , ${2:int sendcounts[]} , ${3:int sdispls[]} , ${4:MPI_Datatype sendtype} , ${5:void* recvbuf} , ${6:int recvcounts[]} , ${7:int rdispls[]} , ${8:MPI_Datatype recvtype} , ${9:MPI_Comm comm} );
+snippet MPI_Bcast_init
+MPI_Bcast_init( ${1:void* buffer} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int root} , ${5:MPI_Comm comm} , ${6:MPI_Info info} , ${7:MPI_Request* request} );
+endsnippet
+snippet MPI_Bsend
+MPI_Bsend( ${1:const void* buf} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} );
 endsnippet
 snippet MPI_Bsend_init
-MPI_Bsend_init( ${1:void* buf} , ${2:int count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
+MPI_Bsend_init( ${1:const void* buf} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
 endsnippet
-snippet MPI_Exscan
-MPI_Exscan( ${1:void* sendbuf} , ${2:void* recvbuf} , ${3:int count} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:MPI_Comm comm} );
+snippet MPI_Buffer_attach
+MPI_Buffer_attach( ${1:void* buffer} , ${2:MPI_Count size} );
 endsnippet
-snippet MPI_Op_free
-MPI_Op_free( ${1:MPI_Op* op} );
-endsnippet
-snippet MPI_Win_set_errhandler
-MPI_Win_set_errhandler( ${1:MPI_Win win} , ${2:MPI_Errhandler errhandler} );
-endsnippet
-snippet MPI_Accumulate
-MPI_Accumulate( ${1:void* origin_addr} , ${2:int origin_count} , ${3:MPI_Datatype origin_datatype} , ${4:int target_rank} , ${5:MPI_Aint target_disp} , ${6:int target_count} , ${7:MPI_Datatype target_datatype} , ${8:MPI_Op op} , ${9:MPI_Win win} );
-endsnippet
-snippet MPI_Comm_get_name
-MPI_Comm_get_name( ${1:MPI_Comm comm} , ${2:char* comm_name} , ${3:int* resultlen} );
-endsnippet
-snippet MPI_Cart_sub
-MPI_Cart_sub( ${1:MPI_Comm comm} , ${2:int remain_dims[]} , ${3:MPI_Comm* new_comm} );
-endsnippet
-snippet MPI_File_write_ordered
-MPI_File_write_ordered( ${1:MPI_File fh} , ${2:void* buf} , ${3:int count} , ${4:MPI_Datatype datatype} , ${5:MPI_Status* status} );
-endsnippet
-snippet MPI_Group_range_excl
-MPI_Group_range_excl( ${1:MPI_Group group} , ${2:int n} , ${3:int ranges[][3]} , ${4:MPI_Group* newgroup} );
-endsnippet
-snippet MPI_Comm_split
-MPI_Comm_split( ${1:MPI_Comm comm} , ${2:int color} , ${3:int key} , ${4:MPI_Comm* newcomm} );
-endsnippet
-snippet MPI_Comm_set_errhandler
-MPI_Comm_set_errhandler( ${1:MPI_Comm comm} , ${2:MPI_Errhandler errhandler} );
-endsnippet
-snippet MPI_Request_get_status
-MPI_Request_get_status( ${1:MPI_Request request} , ${2:int* flag} , ${3:MPI_Status* status} );
-endsnippet
-snippet MPI_Group_free
-MPI_Group_free( ${1:MPI_Group* group} );
-endsnippet
-snippet MPI_Type_create_keyval
-MPI_Type_create_keyval( ${1:MPI_Type_copy_attr_function* type_copy_attr_fn} , ${2:MPI_Type_delete_attr_function* type_delete_attr_fn} , ${3:int* type_keyval} , ${4:void* extra_state} );
-endsnippet
-snippet MPI_File_write_ordered_begin
-MPI_File_write_ordered_begin( ${1:MPI_File fh} , ${2:void* buf} , ${3:int count} , ${4:MPI_Datatype datatype} );
-endsnippet
-snippet MPI_File_read_ordered_begin
-MPI_File_read_ordered_begin( ${1:MPI_File fh} , ${2:void* buf} , ${3:int count} , ${4:MPI_Datatype datatype} );
-endsnippet
-snippet MPI_Graphdims_get
-MPI_Graphdims_get( ${1:MPI_Comm comm} , ${2:int* nnodes} , ${3:int* nedges} );
-endsnippet
-snippet MPI_Comm_rank
-MPI_Comm_rank( ${1:MPI_Comm comm} , ${2:int* rank} );
+snippet MPI_Buffer_detach
+MPI_Buffer_detach( ${1:void* buffer_addr} , ${2:MPI_Count* size} );
 endsnippet
 snippet MPI_Cancel
 MPI_Cancel( ${1:MPI_Request* request} );
 endsnippet
-snippet MPI_Win_fence
-MPI_Win_fence( ${1:int assert} , ${2:MPI_Win win} );
+snippet MPI_Cart_coords
+MPI_Cart_coords( ${1:MPI_Comm comm} , ${2:int rank} , ${3:int maxdims} , ${4:int coords[]} );
 endsnippet
-snippet MPI_Win_create_keyval
-MPI_Win_create_keyval( ${1:MPI_Win_copy_attr_function* win_copy_attr_fn} , ${2:MPI_Win_delete_attr_function* win_delete_attr_fn} , ${3:int* win_keyval} , ${4:void* extra_state} );
+snippet MPI_Cart_create
+MPI_Cart_create( ${1:MPI_Comm comm_old} , ${2:int ndims} , ${3:const int dims[]} , ${4:const int periods[]} , ${5:int reorder} , ${6:MPI_Comm* comm_cart} );
+endsnippet
+snippet MPI_Cart_get
+MPI_Cart_get( ${1:MPI_Comm comm} , ${2:int maxdims} , ${3:int dims[]} , ${4:int periods[]} , ${5:int coords[]} );
+endsnippet
+snippet MPI_Cart_map
+MPI_Cart_map( ${1:MPI_Comm comm} , ${2:int ndims} , ${3:const int dims[]} , ${4:const int periods[]} , ${5:int* newrank} );
+endsnippet
+snippet MPI_Cart_rank
+MPI_Cart_rank( ${1:MPI_Comm comm} , ${2:const int coords[]} , ${3:int* rank} );
+endsnippet
+snippet MPI_Cart_shift
+MPI_Cart_shift( ${1:MPI_Comm comm} , ${2:int direction} , ${3:int disp} , ${4:int* rank_source} , ${5:int* rank_dest} );
+endsnippet
+snippet MPI_Cart_sub
+MPI_Cart_sub( ${1:MPI_Comm comm} , ${2:const int remain_dims[]} , ${3:MPI_Comm* newcomm} );
+endsnippet
+snippet MPI_Cartdim_get
+MPI_Cartdim_get( ${1:MPI_Comm comm} , ${2:int* ndims} );
+endsnippet
+snippet MPI_Close_port
+MPI_Close_port( ${1:const char* port_name} );
+endsnippet
+snippet MPI_Comm_accept
+MPI_Comm_accept( ${1:const char* port_name} , ${2:MPI_Info info} , ${3:int root} , ${4:MPI_Comm comm} , ${5:MPI_Comm* newcomm} );
+endsnippet
+snippet MPI_Comm_call_errhandler
+MPI_Comm_call_errhandler( ${1:MPI_Comm comm} , ${2:int errorcode} );
+endsnippet
+snippet MPI_Comm_compare
+MPI_Comm_compare( ${1:MPI_Comm comm1} , ${2:MPI_Comm comm2} , ${3:int* result} );
+endsnippet
+snippet MPI_Comm_connect
+MPI_Comm_connect( ${1:const char* port_name} , ${2:MPI_Info info} , ${3:int root} , ${4:MPI_Comm comm} , ${5:MPI_Comm* newcomm} );
+endsnippet
+snippet MPI_Comm_create
+MPI_Comm_create( ${1:MPI_Comm comm} , ${2:MPI_Group group} , ${3:MPI_Comm* newcomm} );
+endsnippet
+snippet MPI_Comm_create_errhandler
+MPI_Comm_create_errhandler( ${1:MPI_Comm_errhandler_function* comm_errhandler_fn} , ${2:MPI_Errhandler* errhandler} );
+endsnippet
+snippet MPI_Comm_create_from_group
+MPI_Comm_create_from_group( ${1:MPI_Group group} , ${2:const char* stringtag} , ${3:MPI_Info info} , ${4:MPI_Errhandler errhandler} , ${5:MPI_Comm* newcomm} );
+endsnippet
+snippet MPI_Comm_create_group
+MPI_Comm_create_group( ${1:MPI_Comm comm} , ${2:MPI_Group group} , ${3:int tag} , ${4:MPI_Comm* newcomm} );
+endsnippet
+snippet MPI_Comm_create_keyval
+MPI_Comm_create_keyval( ${1:MPI_Comm_copy_attr_function* comm_copy_attr_fn} , ${2:MPI_Comm_delete_attr_function* comm_delete_attr_fn} , ${3:int* comm_keyval} , ${4:void* extra_state} );
+endsnippet
+snippet MPI_Comm_delete_attr
+MPI_Comm_delete_attr( ${1:MPI_Comm comm} , ${2:int comm_keyval} );
+endsnippet
+snippet MPI_Comm_disconnect
+MPI_Comm_disconnect( ${1:MPI_Comm* comm} );
+endsnippet
+snippet MPI_Comm_dup
+MPI_Comm_dup( ${1:MPI_Comm comm} , ${2:MPI_Comm* newcomm} );
+endsnippet
+snippet MPI_Comm_dup_with_info
+MPI_Comm_dup_with_info( ${1:MPI_Comm comm} , ${2:MPI_Info info} , ${3:MPI_Comm* newcomm} );
+endsnippet
+snippet MPI_Comm_free
+MPI_Comm_free( ${1:MPI_Comm* comm} );
+endsnippet
+snippet MPI_Comm_free_keyval
+MPI_Comm_free_keyval( ${1:int* comm_keyval} );
+endsnippet
+snippet MPI_Comm_get_attr
+MPI_Comm_get_attr( ${1:MPI_Comm comm} , ${2:int comm_keyval} , ${3:void* attribute_val} , ${4:int* flag} );
+endsnippet
+snippet MPI_Comm_get_errhandler
+MPI_Comm_get_errhandler( ${1:MPI_Comm comm} , ${2:MPI_Errhandler* errhandler} );
+endsnippet
+snippet MPI_Comm_get_info
+MPI_Comm_get_info( ${1:MPI_Comm comm} , ${2:MPI_Info* info_used} );
+endsnippet
+snippet MPI_Comm_get_name
+MPI_Comm_get_name( ${1:MPI_Comm comm} , ${2:char* comm_name} , ${3:int* resultlen} );
+endsnippet
+snippet MPI_Comm_get_parent
+MPI_Comm_get_parent( ${1:MPI_Comm* parent} );
+endsnippet
+snippet MPI_Comm_group
+MPI_Comm_group( ${1:MPI_Comm comm} , ${2:MPI_Group* group} );
+endsnippet
+snippet MPI_Comm_idup
+MPI_Comm_idup( ${1:MPI_Comm comm} , ${2:MPI_Comm* newcomm} , ${3:MPI_Request* request} );
+endsnippet
+snippet MPI_Comm_idup_with_info
+MPI_Comm_idup_with_info( ${1:MPI_Comm comm} , ${2:MPI_Info info} , ${3:MPI_Comm* newcomm} , ${4:MPI_Request* request} );
+endsnippet
+snippet MPI_Comm_join
+MPI_Comm_join( ${1:int fd} , ${2:MPI_Comm* intercomm} );
+endsnippet
+snippet MPI_Comm_rank
+MPI_Comm_rank( ${1:MPI_Comm comm} , ${2:int* rank} );
+endsnippet
+snippet MPI_Comm_remote_group
+MPI_Comm_remote_group( ${1:MPI_Comm comm} , ${2:MPI_Group* group} );
+endsnippet
+snippet MPI_Comm_remote_size
+MPI_Comm_remote_size( ${1:MPI_Comm comm} , ${2:int* size} );
+endsnippet
+snippet MPI_Comm_set_attr
+MPI_Comm_set_attr( ${1:MPI_Comm comm} , ${2:int comm_keyval} , ${3:void* attribute_val} );
+endsnippet
+snippet MPI_Comm_set_errhandler
+MPI_Comm_set_errhandler( ${1:MPI_Comm comm} , ${2:MPI_Errhandler errhandler} );
+endsnippet
+snippet MPI_Comm_set_info
+MPI_Comm_set_info( ${1:MPI_Comm comm} , ${2:MPI_Info info} );
+endsnippet
+snippet MPI_Comm_set_name
+MPI_Comm_set_name( ${1:MPI_Comm comm} , ${2:const char* comm_name} );
+endsnippet
+snippet MPI_Comm_size
+MPI_Comm_size( ${1:MPI_Comm comm} , ${2:int* size} );
+endsnippet
+snippet MPI_Comm_spawn
+MPI_Comm_spawn( ${1:const char* command} , ${2:char* argv[]} , ${3:int maxprocs} , ${4:MPI_Info info} , ${5:int root} , ${6:MPI_Comm comm} , ${7:MPI_Comm* intercomm} , ${8:int array_of_errcodes[]} );
+endsnippet
+snippet MPI_Comm_spawn_multiple
+MPI_Comm_spawn_multiple( ${1:int count} , ${2:char* array_of_commands[]} , ${3:char** array_of_argv[]} , ${4:const int array_of_maxprocs[]} , ${5:const MPI_Info array_of_info[]} , ${6:int root} , ${7:MPI_Comm comm} , ${8:MPI_Comm* intercomm} , ${9:int array_of_errcodes[]} );
+endsnippet
+snippet MPI_Comm_split
+MPI_Comm_split( ${1:MPI_Comm comm} , ${2:int color} , ${3:int key} , ${4:MPI_Comm* newcomm} );
+endsnippet
+snippet MPI_Comm_split_type
+MPI_Comm_split_type( ${1:MPI_Comm comm} , ${2:int split_type} , ${3:int key} , ${4:MPI_Info info} , ${5:MPI_Comm* newcomm} );
+endsnippet
+snippet MPI_Comm_test_inter
+MPI_Comm_test_inter( ${1:MPI_Comm comm} , ${2:int* flag} );
+endsnippet
+snippet MPI_Compare_and_swap
+MPI_Compare_and_swap( ${1:const void* origin_addr} , ${2:const void* compare_addr} , ${3:void* result_addr} , ${4:MPI_Datatype datatype} , ${5:int target_rank} , ${6:MPI_Aint target_disp} , ${7:MPI_Win win} );
+endsnippet
+snippet MPI_Dims_create
+MPI_Dims_create( ${1:int nnodes} , ${2:int ndims} , ${3:int dims[]} );
+endsnippet
+snippet MPI_Dist_graph_create
+MPI_Dist_graph_create( ${1:MPI_Comm comm_old} , ${2:int n} , ${3:const int sources[]} , ${4:const int degrees[]} , ${5:const int destinations[]} , ${6:const int weights[]} , ${7:MPI_Info info} , ${8:int reorder} , ${9:MPI_Comm* comm_dist_graph} );
+endsnippet
+snippet MPI_Dist_graph_create_adjacent
+MPI_Dist_graph_create_adjacent( ${1:MPI_Comm comm_old} , ${2:int indegree} , ${3:const int sources[]} , ${4:const int sourceweights[]} , ${5:int outdegree} , ${6:const int destinations[]} , ${7:const int destweights[]} , ${8:MPI_Info info} , ${9:int reorder} , ${10:MPI_Comm* comm_dist_graph} );
+endsnippet
+snippet MPI_Dist_graph_neighbors
+MPI_Dist_graph_neighbors( ${1:MPI_Comm comm} , ${2:int maxindegree} , ${3:int sources[]} , ${4:int sourceweights[]} , ${5:int maxoutdegree} , ${6:int destinations[]} , ${7:int destweights[]} );
+endsnippet
+snippet MPI_Dist_graph_neighbors_count
+MPI_Dist_graph_neighbors_count( ${1:MPI_Comm comm} , ${2:int* indegree} , ${3:int* outdegree} , ${4:int* weighted} );
 endsnippet
 snippet MPI_Errhandler_free
 MPI_Errhandler_free( ${1:MPI_Errhandler* errhandler} );
 endsnippet
+snippet MPI_Error_class
+MPI_Error_class( ${1:int errorcode} , ${2:int* errorclass} );
+endsnippet
+snippet MPI_Error_string
+MPI_Error_string( ${1:int errorcode} , ${2:char* string} , ${3:int* resultlen} );
+endsnippet
+snippet MPI_Exscan
+MPI_Exscan( ${1:const void* sendbuf} , ${2:void* recvbuf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:MPI_Comm comm} );
+endsnippet
+snippet MPI_Exscan_init
+MPI_Exscan_init( ${1:const void* sendbuf} , ${2:void* recvbuf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:MPI_Comm comm} , ${7:MPI_Info info} , ${8:MPI_Request* request} );
+endsnippet
+snippet MPI_Fetch_and_op
+MPI_Fetch_and_op( ${1:const void* origin_addr} , ${2:void* result_addr} , ${3:MPI_Datatype datatype} , ${4:int target_rank} , ${5:MPI_Aint target_disp} , ${6:MPI_Op op} , ${7:MPI_Win win} );
+endsnippet
+snippet MPI_File_call_errhandler
+MPI_File_call_errhandler( ${1:MPI_File fh} , ${2:int errorcode} );
+endsnippet
+snippet MPI_File_close
+MPI_File_close( ${1:MPI_File* fh} );
+endsnippet
+snippet MPI_File_create_errhandler
+MPI_File_create_errhandler( ${1:MPI_File_errhandler_function* file_errhandler_fn} , ${2:MPI_Errhandler* errhandler} );
+endsnippet
+snippet MPI_File_delete
+MPI_File_delete( ${1:const char* filename} , ${2:MPI_Info info} );
+endsnippet
+snippet MPI_File_get_amode
+MPI_File_get_amode( ${1:MPI_File fh} , ${2:int* amode} );
+endsnippet
+snippet MPI_File_get_atomicity
+MPI_File_get_atomicity( ${1:MPI_File fh} , ${2:int* flag} );
+endsnippet
+snippet MPI_File_get_byte_offset
+MPI_File_get_byte_offset( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:MPI_Offset* disp} );
+endsnippet
+snippet MPI_File_get_errhandler
+MPI_File_get_errhandler( ${1:MPI_File file} , ${2:MPI_Errhandler* errhandler} );
+endsnippet
+snippet MPI_File_get_group
+MPI_File_get_group( ${1:MPI_File fh} , ${2:MPI_Group* group} );
+endsnippet
+snippet MPI_File_get_info
+MPI_File_get_info( ${1:MPI_File fh} , ${2:MPI_Info* info_used} );
+endsnippet
+snippet MPI_File_get_position
+MPI_File_get_position( ${1:MPI_File fh} , ${2:MPI_Offset* offset} );
+endsnippet
+snippet MPI_File_get_position_shared
+MPI_File_get_position_shared( ${1:MPI_File fh} , ${2:MPI_Offset* offset} );
+endsnippet
+snippet MPI_File_get_size
+MPI_File_get_size( ${1:MPI_File fh} , ${2:MPI_Offset* size} );
+endsnippet
+snippet MPI_File_get_type_extent
+MPI_File_get_type_extent( ${1:MPI_File fh} , ${2:MPI_Datatype datatype} , ${3:MPI_Count* extent} );
+endsnippet
+snippet MPI_File_get_view
+MPI_File_get_view( ${1:MPI_File fh} , ${2:MPI_Offset* disp} , ${3:MPI_Datatype* etype} , ${4:MPI_Datatype* filetype} , ${5:char* datarep} );
+endsnippet
+snippet MPI_File_iread
+MPI_File_iread( ${1:MPI_File fh} , ${2:void* buf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Request* request} );
+endsnippet
+snippet MPI_File_iread_all
+MPI_File_iread_all( ${1:MPI_File fh} , ${2:void* buf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Request* request} );
+endsnippet
+snippet MPI_File_iread_at
+MPI_File_iread_at( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:void* buf} , ${4:MPI_Count count} , ${5:MPI_Datatype datatype} , ${6:MPI_Request* request} );
+endsnippet
+snippet MPI_File_iread_at_all
+MPI_File_iread_at_all( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:void* buf} , ${4:MPI_Count count} , ${5:MPI_Datatype datatype} , ${6:MPI_Request* request} );
+endsnippet
+snippet MPI_File_iread_shared
+MPI_File_iread_shared( ${1:MPI_File fh} , ${2:void* buf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Request* request} );
+endsnippet
+snippet MPI_File_iwrite
+MPI_File_iwrite( ${1:MPI_File fh} , ${2:const void* buf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Request* request} );
+endsnippet
+snippet MPI_File_iwrite_all
+MPI_File_iwrite_all( ${1:MPI_File fh} , ${2:const void* buf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Request* request} );
+endsnippet
+snippet MPI_File_iwrite_at
+MPI_File_iwrite_at( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:const void* buf} , ${4:MPI_Count count} , ${5:MPI_Datatype datatype} , ${6:MPI_Request* request} );
+endsnippet
+snippet MPI_File_iwrite_at_all
+MPI_File_iwrite_at_all( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:const void* buf} , ${4:MPI_Count count} , ${5:MPI_Datatype datatype} , ${6:MPI_Request* request} );
+endsnippet
+snippet MPI_File_iwrite_shared
+MPI_File_iwrite_shared( ${1:MPI_File fh} , ${2:const void* buf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Request* request} );
+endsnippet
+snippet MPI_File_open
+MPI_File_open( ${1:MPI_Comm comm} , ${2:const char* filename} , ${3:int amode} , ${4:MPI_Info info} , ${5:MPI_File* fh} );
+endsnippet
+snippet MPI_File_preallocate
+MPI_File_preallocate( ${1:MPI_File fh} , ${2:MPI_Offset size} );
+endsnippet
+snippet MPI_File_read
+MPI_File_read( ${1:MPI_File fh} , ${2:void* buf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Status* status} );
+endsnippet
+snippet MPI_File_read_all
+MPI_File_read_all( ${1:MPI_File fh} , ${2:void* buf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Status* status} );
+endsnippet
+snippet MPI_File_read_all_begin
+MPI_File_read_all_begin( ${1:MPI_File fh} , ${2:void* buf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} );
+endsnippet
+snippet MPI_File_read_all_end
+MPI_File_read_all_end( ${1:MPI_File fh} , ${2:void* buf} , ${3:MPI_Status* status} );
+endsnippet
+snippet MPI_File_read_at
+MPI_File_read_at( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:void* buf} , ${4:MPI_Count count} , ${5:MPI_Datatype datatype} , ${6:MPI_Status* status} );
+endsnippet
+snippet MPI_File_read_at_all
+MPI_File_read_at_all( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:void* buf} , ${4:MPI_Count count} , ${5:MPI_Datatype datatype} , ${6:MPI_Status* status} );
+endsnippet
+snippet MPI_File_read_at_all_begin
+MPI_File_read_at_all_begin( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:void* buf} , ${4:MPI_Count count} , ${5:MPI_Datatype datatype} );
+endsnippet
+snippet MPI_File_read_at_all_end
+MPI_File_read_at_all_end( ${1:MPI_File fh} , ${2:void* buf} , ${3:MPI_Status* status} );
+endsnippet
+snippet MPI_File_read_ordered
+MPI_File_read_ordered( ${1:MPI_File fh} , ${2:void* buf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Status* status} );
+endsnippet
+snippet MPI_File_read_ordered_begin
+MPI_File_read_ordered_begin( ${1:MPI_File fh} , ${2:void* buf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} );
+endsnippet
+snippet MPI_File_read_ordered_end
+MPI_File_read_ordered_end( ${1:MPI_File fh} , ${2:void* buf} , ${3:MPI_Status* status} );
+endsnippet
+snippet MPI_File_read_shared
+MPI_File_read_shared( ${1:MPI_File fh} , ${2:void* buf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Status* status} );
+endsnippet
+snippet MPI_File_seek
+MPI_File_seek( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:int whence} );
+endsnippet
+snippet MPI_File_seek_shared
+MPI_File_seek_shared( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:int whence} );
+endsnippet
+snippet MPI_File_set_atomicity
+MPI_File_set_atomicity( ${1:MPI_File fh} , ${2:int flag} );
+endsnippet
+snippet MPI_File_set_errhandler
+MPI_File_set_errhandler( ${1:MPI_File file} , ${2:MPI_Errhandler errhandler} );
+endsnippet
+snippet MPI_File_set_info
+MPI_File_set_info( ${1:MPI_File fh} , ${2:MPI_Info info} );
+endsnippet
+snippet MPI_File_set_size
+MPI_File_set_size( ${1:MPI_File fh} , ${2:MPI_Offset size} );
+endsnippet
+snippet MPI_File_set_view
+MPI_File_set_view( ${1:MPI_File fh} , ${2:MPI_Offset disp} , ${3:MPI_Datatype etype} , ${4:MPI_Datatype filetype} , ${5:const char* datarep} , ${6:MPI_Info info} );
+endsnippet
+snippet MPI_File_sync
+MPI_File_sync( ${1:MPI_File fh} );
+endsnippet
+snippet MPI_File_write
+MPI_File_write( ${1:MPI_File fh} , ${2:const void* buf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Status* status} );
+endsnippet
+snippet MPI_File_write_all
+MPI_File_write_all( ${1:MPI_File fh} , ${2:const void* buf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Status* status} );
+endsnippet
+snippet MPI_File_write_all_begin
+MPI_File_write_all_begin( ${1:MPI_File fh} , ${2:const void* buf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} );
+endsnippet
+snippet MPI_File_write_all_end
+MPI_File_write_all_end( ${1:MPI_File fh} , ${2:const void* buf} , ${3:MPI_Status* status} );
+endsnippet
+snippet MPI_File_write_at
+MPI_File_write_at( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:const void* buf} , ${4:MPI_Count count} , ${5:MPI_Datatype datatype} , ${6:MPI_Status* status} );
+endsnippet
+snippet MPI_File_write_at_all
+MPI_File_write_at_all( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:const void* buf} , ${4:MPI_Count count} , ${5:MPI_Datatype datatype} , ${6:MPI_Status* status} );
+endsnippet
+snippet MPI_File_write_at_all_begin
+MPI_File_write_at_all_begin( ${1:MPI_File fh} , ${2:MPI_Offset offset} , ${3:const void* buf} , ${4:MPI_Count count} , ${5:MPI_Datatype datatype} );
+endsnippet
+snippet MPI_File_write_at_all_end
+MPI_File_write_at_all_end( ${1:MPI_File fh} , ${2:const void* buf} , ${3:MPI_Status* status} );
+endsnippet
+snippet MPI_File_write_ordered
+MPI_File_write_ordered( ${1:MPI_File fh} , ${2:const void* buf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Status* status} );
+endsnippet
+snippet MPI_File_write_ordered_begin
+MPI_File_write_ordered_begin( ${1:MPI_File fh} , ${2:const void* buf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} );
+endsnippet
+snippet MPI_File_write_ordered_end
+MPI_File_write_ordered_end( ${1:MPI_File fh} , ${2:const void* buf} , ${3:MPI_Status* status} );
+endsnippet
+snippet MPI_File_write_shared
+MPI_File_write_shared( ${1:MPI_File fh} , ${2:const void* buf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Status* status} );
+endsnippet
+snippet MPI_Finalize
+MPI_Finalize();
+endsnippet
+snippet MPI_Finalized
+MPI_Finalized( ${1:int* flag} );
+endsnippet
+snippet MPI_Free_mem
+MPI_Free_mem( ${1:void* base} );
+endsnippet
+snippet MPI_Gather
+MPI_Gather( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:MPI_Count recvcount} , ${6:MPI_Datatype recvtype} , ${7:int root} , ${8:MPI_Comm comm} );
+endsnippet
+snippet MPI_Gather_init
+MPI_Gather_init( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:MPI_Count recvcount} , ${6:MPI_Datatype recvtype} , ${7:int root} , ${8:MPI_Comm comm} , ${9:MPI_Info info} , ${10:MPI_Request* request} );
+endsnippet
+snippet MPI_Gatherv
+MPI_Gatherv( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:const MPI_Count recvcounts[]} , ${6:const MPI_Aint displs[]} , ${7:MPI_Datatype recvtype} , ${8:int root} , ${9:MPI_Comm comm} );
+endsnippet
+snippet MPI_Gatherv_init
+MPI_Gatherv_init( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:const MPI_Count recvcounts[]} , ${6:const MPI_Aint displs[]} , ${7:MPI_Datatype recvtype} , ${8:int root} , ${9:MPI_Comm comm} , ${10:MPI_Info info} , ${11:MPI_Request* request} );
+endsnippet
+snippet MPI_Get
+MPI_Get( ${1:void* origin_addr} , ${2:MPI_Count origin_count} , ${3:MPI_Datatype origin_datatype} , ${4:int target_rank} , ${5:MPI_Aint target_disp} , ${6:MPI_Count target_count} , ${7:MPI_Datatype target_datatype} , ${8:MPI_Win win} );
+endsnippet
+snippet MPI_Get_accumulate
+MPI_Get_accumulate( ${1:const void* origin_addr} , ${2:MPI_Count origin_count} , ${3:MPI_Datatype origin_datatype} , ${4:void* result_addr} , ${5:MPI_Count result_count} , ${6:MPI_Datatype result_datatype} , ${7:int target_rank} , ${8:MPI_Aint target_disp} , ${9:MPI_Count target_count} , ${10:MPI_Datatype target_datatype} , ${11:MPI_Op op} , ${12:MPI_Win win} );
+endsnippet
+snippet MPI_Get_address
+MPI_Get_address( ${1:const void* location} , ${2:MPI_Aint* address} );
+endsnippet
+snippet MPI_Get_count
+MPI_Get_count( ${1:const MPI_Status* status} , ${2:MPI_Datatype datatype} , ${3:MPI_Count* count} );
+endsnippet
+snippet MPI_Get_elements
+MPI_Get_elements( ${1:const MPI_Status* status} , ${2:MPI_Datatype datatype} , ${3:MPI_Count* count} );
+endsnippet
+snippet MPI_Get_elements_x
+MPI_Get_elements_x( ${1:const MPI_Status* status} , ${2:MPI_Datatype datatype} , ${3:MPI_Count* count} );
+endsnippet
+snippet MPI_Get_library_version
+MPI_Get_library_version( ${1:char* version} , ${2:int* resultlen} );
+endsnippet
+snippet MPI_Get_processor_name
+MPI_Get_processor_name( ${1:char* name} , ${2:int* resultlen} );
+endsnippet
+snippet MPI_Get_version
+MPI_Get_version( ${1:int* version} , ${2:int* subversion} );
+endsnippet
+snippet MPI_Graph_create
+MPI_Graph_create( ${1:MPI_Comm comm_old} , ${2:int nnodes} , ${3:const int index[]} , ${4:const int edges[]} , ${5:int reorder} , ${6:MPI_Comm* comm_graph} );
+endsnippet
+snippet MPI_Graph_get
+MPI_Graph_get( ${1:MPI_Comm comm} , ${2:int maxindex} , ${3:int maxedges} , ${4:int index[]} , ${5:int edges[]} );
+endsnippet
+snippet MPI_Graph_map
+MPI_Graph_map( ${1:MPI_Comm comm} , ${2:int nnodes} , ${3:const int index[]} , ${4:const int edges[]} , ${5:int* newrank} );
+endsnippet
+snippet MPI_Graph_neighbors
+MPI_Graph_neighbors( ${1:MPI_Comm comm} , ${2:int rank} , ${3:int maxneighbors} , ${4:int neighbors[]} );
+endsnippet
+snippet MPI_Graph_neighbors_count
+MPI_Graph_neighbors_count( ${1:MPI_Comm comm} , ${2:int rank} , ${3:int* nneighbors} );
+endsnippet
+snippet MPI_Graphdims_get
+MPI_Graphdims_get( ${1:MPI_Comm comm} , ${2:int* nnodes} , ${3:int* nedges} );
+endsnippet
+snippet MPI_Grequest_complete
+MPI_Grequest_complete( ${1:MPI_Request request} );
+endsnippet
+snippet MPI_Grequest_start
+MPI_Grequest_start( ${1:MPI_Grequest_query_function* query_fn} , ${2:MPI_Grequest_free_function* free_fn} , ${3:MPI_Grequest_cancel_function* cancel_fn} , ${4:void* extra_state} , ${5:MPI_Request* request} );
+endsnippet
+snippet MPI_Group_compare
+MPI_Group_compare( ${1:MPI_Group group1} , ${2:MPI_Group group2} , ${3:int* result} );
+endsnippet
+snippet MPI_Group_difference
+MPI_Group_difference( ${1:MPI_Group group1} , ${2:MPI_Group group2} , ${3:MPI_Group* newgroup} );
+endsnippet
+snippet MPI_Group_excl
+MPI_Group_excl( ${1:MPI_Group group} , ${2:int n} , ${3:const int ranks[]} , ${4:MPI_Group* newgroup} );
+endsnippet
+snippet MPI_Group_free
+MPI_Group_free( ${1:MPI_Group* group} );
+endsnippet
+snippet MPI_Group_from_session_pset
+MPI_Group_from_session_pset( ${1:MPI_Session session} , ${2:const char* pset_name} , ${3:MPI_Group* newgroup} );
+endsnippet
+snippet MPI_Group_incl
+MPI_Group_incl( ${1:MPI_Group group} , ${2:int n} , ${3:const int ranks[]} , ${4:MPI_Group* newgroup} );
+endsnippet
+snippet MPI_Group_intersection
+MPI_Group_intersection( ${1:MPI_Group group1} , ${2:MPI_Group group2} , ${3:MPI_Group* newgroup} );
+endsnippet
+snippet MPI_Group_range_excl
+MPI_Group_range_excl( ${1:MPI_Group group} , ${2:int n} , ${3:int ranges[][3]} , ${4:MPI_Group* newgroup} );
+endsnippet
+snippet MPI_Group_range_incl
+MPI_Group_range_incl( ${1:MPI_Group group} , ${2:int n} , ${3:int ranges[][3]} , ${4:MPI_Group* newgroup} );
+endsnippet
+snippet MPI_Group_rank
+MPI_Group_rank( ${1:MPI_Group group} , ${2:int* rank} );
+endsnippet
+snippet MPI_Group_size
+MPI_Group_size( ${1:MPI_Group group} , ${2:int* size} );
+endsnippet
+snippet MPI_Group_translate_ranks
+MPI_Group_translate_ranks( ${1:MPI_Group group1} , ${2:int n} , ${3:const int ranks1[]} , ${4:MPI_Group group2} , ${5:int ranks2[]} );
+endsnippet
+snippet MPI_Group_union
+MPI_Group_union( ${1:MPI_Group group1} , ${2:MPI_Group group2} , ${3:MPI_Group* newgroup} );
+endsnippet
+snippet MPI_Iallgather
+MPI_Iallgather( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:MPI_Count recvcount} , ${6:MPI_Datatype recvtype} , ${7:MPI_Comm comm} , ${8:MPI_Request* request} );
+endsnippet
+snippet MPI_Iallgatherv
+MPI_Iallgatherv( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:const MPI_Count recvcounts[]} , ${6:const MPI_Aint displs[]} , ${7:MPI_Datatype recvtype} , ${8:MPI_Comm comm} , ${9:MPI_Request* request} );
+endsnippet
+snippet MPI_Iallreduce
+MPI_Iallreduce( ${1:const void* sendbuf} , ${2:void* recvbuf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
+endsnippet
+snippet MPI_Ialltoall
+MPI_Ialltoall( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:MPI_Count recvcount} , ${6:MPI_Datatype recvtype} , ${7:MPI_Comm comm} , ${8:MPI_Request* request} );
+endsnippet
+snippet MPI_Ialltoallv
+MPI_Ialltoallv( ${1:const void* sendbuf} , ${2:const MPI_Count sendcounts[]} , ${3:const MPI_Aint sdispls[]} , ${4:MPI_Datatype sendtype} , ${5:void* recvbuf} , ${6:const MPI_Count recvcounts[]} , ${7:const MPI_Aint rdispls[]} , ${8:MPI_Datatype recvtype} , ${9:MPI_Comm comm} , ${10:MPI_Request* request} );
+endsnippet
+snippet MPI_Ialltoallw
+MPI_Ialltoallw( ${1:const void* sendbuf} , ${2:const MPI_Count sendcounts[]} , ${3:const MPI_Aint sdispls[]} , ${4:const MPI_Datatype sendtypes[]} , ${5:void* recvbuf} , ${6:const MPI_Count recvcounts[]} , ${7:const MPI_Aint rdispls[]} , ${8:const MPI_Datatype recvtypes[]} , ${9:MPI_Comm comm} , ${10:MPI_Request* request} );
+endsnippet
+snippet MPI_Ibarrier
+MPI_Ibarrier( ${1:MPI_Comm comm} , ${2:MPI_Request* request} );
+endsnippet
+snippet MPI_Ibcast
+MPI_Ibcast( ${1:void* buffer} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int root} , ${5:MPI_Comm comm} , ${6:MPI_Request* request} );
+endsnippet
+snippet MPI_Ibsend
+MPI_Ibsend( ${1:const void* buf} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
+endsnippet
+snippet MPI_Iexscan
+MPI_Iexscan( ${1:const void* sendbuf} , ${2:void* recvbuf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
+endsnippet
+snippet MPI_Igather
+MPI_Igather( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:MPI_Count recvcount} , ${6:MPI_Datatype recvtype} , ${7:int root} , ${8:MPI_Comm comm} , ${9:MPI_Request* request} );
+endsnippet
+snippet MPI_Igatherv
+MPI_Igatherv( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:const MPI_Count recvcounts[]} , ${6:const MPI_Aint displs[]} , ${7:MPI_Datatype recvtype} , ${8:int root} , ${9:MPI_Comm comm} , ${10:MPI_Request* request} );
+endsnippet
+snippet MPI_Improbe
+MPI_Improbe( ${1:int source} , ${2:int tag} , ${3:MPI_Comm comm} , ${4:int* flag} , ${5:MPI_Message* message} , ${6:MPI_Status* status} );
+endsnippet
+snippet MPI_Imrecv
+MPI_Imrecv( ${1:void* buf} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:MPI_Message* message} , ${5:MPI_Request* request} );
+endsnippet
+snippet MPI_Ineighbor_allgather
+MPI_Ineighbor_allgather( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:MPI_Count recvcount} , ${6:MPI_Datatype recvtype} , ${7:MPI_Comm comm} , ${8:MPI_Request* request} );
+endsnippet
+snippet MPI_Ineighbor_allgatherv
+MPI_Ineighbor_allgatherv( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:const MPI_Count recvcounts[]} , ${6:const MPI_Aint displs[]} , ${7:MPI_Datatype recvtype} , ${8:MPI_Comm comm} , ${9:MPI_Request* request} );
+endsnippet
+snippet MPI_Ineighbor_alltoall
+MPI_Ineighbor_alltoall( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:MPI_Count recvcount} , ${6:MPI_Datatype recvtype} , ${7:MPI_Comm comm} , ${8:MPI_Request* request} );
+endsnippet
+snippet MPI_Ineighbor_alltoallv
+MPI_Ineighbor_alltoallv( ${1:const void* sendbuf} , ${2:const MPI_Count sendcounts[]} , ${3:const MPI_Aint sdispls[]} , ${4:MPI_Datatype sendtype} , ${5:void* recvbuf} , ${6:const MPI_Count recvcounts[]} , ${7:const MPI_Aint rdispls[]} , ${8:MPI_Datatype recvtype} , ${9:MPI_Comm comm} , ${10:MPI_Request* request} );
+endsnippet
+snippet MPI_Ineighbor_alltoallw
+MPI_Ineighbor_alltoallw( ${1:const void* sendbuf} , ${2:const MPI_Count sendcounts[]} , ${3:const MPI_Aint sdispls[]} , ${4:const MPI_Datatype sendtypes[]} , ${5:void* recvbuf} , ${6:const MPI_Count recvcounts[]} , ${7:const MPI_Aint rdispls[]} , ${8:const MPI_Datatype recvtypes[]} , ${9:MPI_Comm comm} , ${10:MPI_Request* request} );
+endsnippet
+snippet MPI_Info_create
+MPI_Info_create( ${1:MPI_Info* info} );
+endsnippet
+snippet MPI_Info_create_env
+MPI_Info_create_env( ${1:int argc} , ${2:char argv[]} , ${3:MPI_Info* info} );
+endsnippet
+snippet MPI_Info_delete
+MPI_Info_delete( ${1:MPI_Info info} , ${2:const char* key} );
+endsnippet
+snippet MPI_Info_dup
+MPI_Info_dup( ${1:MPI_Info info} , ${2:MPI_Info* newinfo} );
+endsnippet
+snippet MPI_Info_free
+MPI_Info_free( ${1:MPI_Info* info} );
+endsnippet
+snippet MPI_Info_get
+MPI_Info_get( ${1:MPI_Info info} , ${2:const char* key} , ${3:int valuelen} , ${4:char* value} , ${5:int* flag} );
+endsnippet
+snippet MPI_Info_get_nkeys
+MPI_Info_get_nkeys( ${1:MPI_Info info} , ${2:int* nkeys} );
+endsnippet
+snippet MPI_Info_get_nthkey
+MPI_Info_get_nthkey( ${1:MPI_Info info} , ${2:int n} , ${3:char* key} );
+endsnippet
+snippet MPI_Info_get_string
+MPI_Info_get_string( ${1:MPI_Info info} , ${2:const char* key} , ${3:int* buflen} , ${4:char* value} , ${5:int* flag} );
+endsnippet
+snippet MPI_Info_get_valuelen
+MPI_Info_get_valuelen( ${1:MPI_Info info} , ${2:const char* key} , ${3:int* valuelen} , ${4:int* flag} );
+endsnippet
+snippet MPI_Info_set
+MPI_Info_set( ${1:MPI_Info info} , ${2:const char* key} , ${3:const char* value} );
+endsnippet
+snippet MPI_Init
+MPI_Init( ${1:int* argc} , ${2:char*** argv} );
+endsnippet
+snippet MPI_Init_thread
+MPI_Init_thread( ${1:int* argc} , ${2:char*** argv} , ${3:int required} , ${4:int* provided} );
+endsnippet
+snippet MPI_Initialized
+MPI_Initialized( ${1:int* flag} );
+endsnippet
+snippet MPI_Intercomm_create
+MPI_Intercomm_create( ${1:MPI_Comm local_comm} , ${2:int local_leader} , ${3:MPI_Comm peer_comm} , ${4:int remote_leader} , ${5:int tag} , ${6:MPI_Comm* newintercomm} );
+endsnippet
+snippet MPI_Intercomm_create_from_groups
+MPI_Intercomm_create_from_groups( ${1:MPI_Group local_group} , ${2:int local_leader} , ${3:MPI_Group remote_group} , ${4:int remote_leader} , ${5:const char* stringtag} , ${6:MPI_Info info} , ${7:MPI_Errhandler errhandler} , ${8:MPI_Comm* newintercomm} );
+endsnippet
+snippet MPI_Intercomm_merge
+MPI_Intercomm_merge( ${1:MPI_Comm intercomm} , ${2:int high} , ${3:MPI_Comm* newintracomm} );
+endsnippet
+snippet MPI_Iprobe
+MPI_Iprobe( ${1:int source} , ${2:int tag} , ${3:MPI_Comm comm} , ${4:int* flag} , ${5:MPI_Status* status} );
+endsnippet
+snippet MPI_Irecv
+MPI_Irecv( ${1:void* buf} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int source} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
+endsnippet
+snippet MPI_Ireduce
+MPI_Ireduce( ${1:const void* sendbuf} , ${2:void* recvbuf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:int root} , ${7:MPI_Comm comm} , ${8:MPI_Request* request} );
+endsnippet
+snippet MPI_Ireduce_scatter
+MPI_Ireduce_scatter( ${1:const void* sendbuf} , ${2:void* recvbuf} , ${3:const MPI_Count recvcounts[]} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
+endsnippet
+snippet MPI_Ireduce_scatter_block
+MPI_Ireduce_scatter_block( ${1:const void* sendbuf} , ${2:void* recvbuf} , ${3:MPI_Count recvcount} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
+endsnippet
+snippet MPI_Irsend
+MPI_Irsend( ${1:const void* buf} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
+endsnippet
+snippet MPI_Is_thread_main
+MPI_Is_thread_main( ${1:int* flag} );
+endsnippet
+snippet MPI_Iscan
+MPI_Iscan( ${1:const void* sendbuf} , ${2:void* recvbuf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
+endsnippet
+snippet MPI_Iscatter
+MPI_Iscatter( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:MPI_Count recvcount} , ${6:MPI_Datatype recvtype} , ${7:int root} , ${8:MPI_Comm comm} , ${9:MPI_Request* request} );
+endsnippet
+snippet MPI_Iscatterv
+MPI_Iscatterv( ${1:const void* sendbuf} , ${2:const MPI_Count sendcounts[]} , ${3:const MPI_Aint displs[]} , ${4:MPI_Datatype sendtype} , ${5:void* recvbuf} , ${6:MPI_Count recvcount} , ${7:MPI_Datatype recvtype} , ${8:int root} , ${9:MPI_Comm comm} , ${10:MPI_Request* request} );
+endsnippet
+snippet MPI_Isend
+MPI_Isend( ${1:const void* buf} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
+endsnippet
+snippet MPI_Isendrecv
+MPI_Isendrecv( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:int dest} , ${5:int sendtag} , ${6:void* recvbuf} , ${7:MPI_Count recvcount} , ${8:MPI_Datatype recvtype} , ${9:int source} , ${10:int recvtag} , ${11:MPI_Comm comm} , ${12:MPI_Request* request} );
+endsnippet
+snippet MPI_Isendrecv_replace
+MPI_Isendrecv_replace( ${1:void* buf} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int sendtag} , ${6:int source} , ${7:int recvtag} , ${8:MPI_Comm comm} , ${9:MPI_Request* request} );
+endsnippet
+snippet MPI_Issend
+MPI_Issend( ${1:const void* buf} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
+endsnippet
+snippet MPI_Keyval_create
+MPI_Keyval_create( ${1:MPI_Copy_function* copy_fn} , ${2:MPI_Delete_function* delete_fn} , ${3:int* keyval} , ${4:void* extra_state} );
+endsnippet
+snippet MPI_Keyval_free
+MPI_Keyval_free( ${1:int* keyval} );
+endsnippet
+snippet MPI_Lookup_name
+MPI_Lookup_name( ${1:const char* service_name} , ${2:MPI_Info info} , ${3:char* port_name} );
+endsnippet
+snippet MPI_Mprobe
+MPI_Mprobe( ${1:int source} , ${2:int tag} , ${3:MPI_Comm comm} , ${4:MPI_Message* message} , ${5:MPI_Status* status} );
+endsnippet
+snippet MPI_Mrecv
+MPI_Mrecv( ${1:void* buf} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:MPI_Message* message} , ${5:MPI_Status* status} );
+endsnippet
+snippet MPI_Neighbor_allgather
+MPI_Neighbor_allgather( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:MPI_Count recvcount} , ${6:MPI_Datatype recvtype} , ${7:MPI_Comm comm} );
+endsnippet
+snippet MPI_Neighbor_allgather_init
+MPI_Neighbor_allgather_init( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:MPI_Count recvcount} , ${6:MPI_Datatype recvtype} , ${7:MPI_Comm comm} , ${8:MPI_Info info} , ${9:MPI_Request* request} );
+endsnippet
+snippet MPI_Neighbor_allgatherv
+MPI_Neighbor_allgatherv( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:const MPI_Count recvcounts[]} , ${6:const MPI_Aint displs[]} , ${7:MPI_Datatype recvtype} , ${8:MPI_Comm comm} );
+endsnippet
+snippet MPI_Neighbor_allgatherv_init
+MPI_Neighbor_allgatherv_init( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:const MPI_Count recvcounts[]} , ${6:const MPI_Aint displs[]} , ${7:MPI_Datatype recvtype} , ${8:MPI_Comm comm} , ${9:MPI_Info info} , ${10:MPI_Request* request} );
+endsnippet
+snippet MPI_Neighbor_alltoall
+MPI_Neighbor_alltoall( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:MPI_Count recvcount} , ${6:MPI_Datatype recvtype} , ${7:MPI_Comm comm} );
+endsnippet
+snippet MPI_Neighbor_alltoall_init
+MPI_Neighbor_alltoall_init( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:MPI_Count recvcount} , ${6:MPI_Datatype recvtype} , ${7:MPI_Comm comm} , ${8:MPI_Info info} , ${9:MPI_Request* request} );
+endsnippet
+snippet MPI_Neighbor_alltoallv
+MPI_Neighbor_alltoallv( ${1:const void* sendbuf} , ${2:const MPI_Count sendcounts[]} , ${3:const MPI_Aint sdispls[]} , ${4:MPI_Datatype sendtype} , ${5:void* recvbuf} , ${6:const MPI_Count recvcounts[]} , ${7:const MPI_Aint rdispls[]} , ${8:MPI_Datatype recvtype} , ${9:MPI_Comm comm} );
+endsnippet
+snippet MPI_Neighbor_alltoallv_init
+MPI_Neighbor_alltoallv_init( ${1:const void* sendbuf} , ${2:const MPI_Count sendcounts[]} , ${3:const MPI_Aint sdispls[]} , ${4:MPI_Datatype sendtype} , ${5:void* recvbuf} , ${6:const MPI_Count recvcounts[]} , ${7:const MPI_Aint rdispls[]} , ${8:MPI_Datatype recvtype} , ${9:MPI_Comm comm} , ${10:MPI_Info info} , ${11:MPI_Request* request} );
+endsnippet
+snippet MPI_Neighbor_alltoallw
+MPI_Neighbor_alltoallw( ${1:const void* sendbuf} , ${2:const MPI_Count sendcounts[]} , ${3:const MPI_Aint sdispls[]} , ${4:const MPI_Datatype sendtypes[]} , ${5:void* recvbuf} , ${6:const MPI_Count recvcounts[]} , ${7:const MPI_Aint rdispls[]} , ${8:const MPI_Datatype recvtypes[]} , ${9:MPI_Comm comm} );
+endsnippet
+snippet MPI_Neighbor_alltoallw_init
+MPI_Neighbor_alltoallw_init( ${1:const void* sendbuf} , ${2:const MPI_Count sendcounts[]} , ${3:const MPI_Aint sdispls[]} , ${4:const MPI_Datatype sendtypes[]} , ${5:void* recvbuf} , ${6:const MPI_Count recvcounts[]} , ${7:const MPI_Aint rdispls[]} , ${8:const MPI_Datatype recvtypes[]} , ${9:MPI_Comm comm} , ${10:MPI_Info info} , ${11:MPI_Request* request} );
+endsnippet
+snippet MPI_Op_commutative
+MPI_Op_commutative( ${1:MPI_Op op} , ${2:int* commute} );
+endsnippet
+snippet MPI_Op_create
+MPI_Op_create( ${1:MPI_User_function* user_fn} , ${2:int commute} , ${3:MPI_Op* op} );
+endsnippet
+snippet MPI_Op_free
+MPI_Op_free( ${1:MPI_Op* op} );
+endsnippet
+snippet MPI_Open_port
+MPI_Open_port( ${1:MPI_Info info} , ${2:char* port_name} );
+endsnippet
+snippet MPI_Pack
+MPI_Pack( ${1:const void* inbuf} , ${2:MPI_Count incount} , ${3:MPI_Datatype datatype} , ${4:void* outbuf} , ${5:MPI_Count outsize} , ${6:MPI_Count* position} , ${7:MPI_Comm comm} );
+endsnippet
+snippet MPI_Pack_external
+MPI_Pack_external( ${1:const char datarep[]} , ${2:const void* inbuf} , ${3:MPI_Count incount} , ${4:MPI_Datatype datatype} , ${5:void* outbuf} , ${6:MPI_Count outsize} , ${7:MPI_Count* position} );
+endsnippet
+snippet MPI_Pack_external_size
+MPI_Pack_external_size( ${1:const char datarep[]} , ${2:MPI_Count incount} , ${3:MPI_Datatype datatype} , ${4:MPI_Count* size} );
+endsnippet
+snippet MPI_Pack_size
+MPI_Pack_size( ${1:MPI_Count incount} , ${2:MPI_Datatype datatype} , ${3:MPI_Comm comm} , ${4:MPI_Count* size} );
+endsnippet
+snippet MPI_Parrived
+MPI_Parrived( ${1:MPI_Request request} , ${2:int partition} , ${3:int* flag} );
+endsnippet
+snippet MPI_Pcontrol
+MPI_Pcontrol( ${1:const int level} , ${2:... } );
+endsnippet
+snippet MPI_Pready
+MPI_Pready( ${1:int partition} , ${2:MPI_Request request} );
+endsnippet
+snippet MPI_Pready_list
+MPI_Pready_list( ${1:int length} , ${2:const int array_of_partitions[]} , ${3:MPI_Request request} );
+endsnippet
+snippet MPI_Pready_range
+MPI_Pready_range( ${1:int partition_low} , ${2:int partition_high} , ${3:MPI_Request request} );
+endsnippet
+snippet MPI_Precv_init
+MPI_Precv_init( ${1:void* buf} , ${2:int partitions} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:int source} , ${6:int tag} , ${7:MPI_Comm comm} , ${8:MPI_Info info} , ${9:MPI_Request* request} );
+endsnippet
+snippet MPI_Probe
+MPI_Probe( ${1:int source} , ${2:int tag} , ${3:MPI_Comm comm} , ${4:MPI_Status* status} );
+endsnippet
+snippet MPI_Psend_init
+MPI_Psend_init( ${1:const void* buf} , ${2:int partitions} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:int dest} , ${6:int tag} , ${7:MPI_Comm comm} , ${8:MPI_Info info} , ${9:MPI_Request* request} );
+endsnippet
+snippet MPI_Publish_name
+MPI_Publish_name( ${1:const char* service_name} , ${2:MPI_Info info} , ${3:const char* port_name} );
+endsnippet
+snippet MPI_Put
+MPI_Put( ${1:const void* origin_addr} , ${2:MPI_Count origin_count} , ${3:MPI_Datatype origin_datatype} , ${4:int target_rank} , ${5:MPI_Aint target_disp} , ${6:MPI_Count target_count} , ${7:MPI_Datatype target_datatype} , ${8:MPI_Win win} );
+endsnippet
+snippet MPI_Query_thread
+MPI_Query_thread( ${1:int* provided} );
+endsnippet
+snippet MPI_Raccumulate
+MPI_Raccumulate( ${1:const void* origin_addr} , ${2:MPI_Count origin_count} , ${3:MPI_Datatype origin_datatype} , ${4:int target_rank} , ${5:MPI_Aint target_disp} , ${6:MPI_Count target_count} , ${7:MPI_Datatype target_datatype} , ${8:MPI_Op op} , ${9:MPI_Win win} , ${10:MPI_Request* request} );
+endsnippet
+snippet MPI_Recv
+MPI_Recv( ${1:void* buf} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int source} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Status* status} );
+endsnippet
+snippet MPI_Recv_init
+MPI_Recv_init( ${1:void* buf} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int source} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
+endsnippet
+snippet MPI_Reduce
+MPI_Reduce( ${1:const void* sendbuf} , ${2:void* recvbuf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:int root} , ${7:MPI_Comm comm} );
+endsnippet
+snippet MPI_Reduce_init
+MPI_Reduce_init( ${1:const void* sendbuf} , ${2:void* recvbuf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:int root} , ${7:MPI_Comm comm} , ${8:MPI_Info info} , ${9:MPI_Request* request} );
+endsnippet
+snippet MPI_Reduce_local
+MPI_Reduce_local( ${1:const void* inbuf} , ${2:void* inoutbuf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} );
+endsnippet
+snippet MPI_Reduce_scatter
+MPI_Reduce_scatter( ${1:const void* sendbuf} , ${2:void* recvbuf} , ${3:const MPI_Count recvcounts[]} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:MPI_Comm comm} );
+endsnippet
+snippet MPI_Reduce_scatter_block
+MPI_Reduce_scatter_block( ${1:const void* sendbuf} , ${2:void* recvbuf} , ${3:MPI_Count recvcount} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:MPI_Comm comm} );
+endsnippet
+snippet MPI_Reduce_scatter_block_init
+MPI_Reduce_scatter_block_init( ${1:const void* sendbuf} , ${2:void* recvbuf} , ${3:MPI_Count recvcount} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:MPI_Comm comm} , ${7:MPI_Info info} , ${8:MPI_Request* request} );
+endsnippet
+snippet MPI_Reduce_scatter_init
+MPI_Reduce_scatter_init( ${1:const void* sendbuf} , ${2:void* recvbuf} , ${3:const MPI_Count recvcounts[]} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:MPI_Comm comm} , ${7:MPI_Info info} , ${8:MPI_Request* request} );
+endsnippet
+snippet MPI_Register_datarep
+MPI_Register_datarep( ${1:const char* datarep} , ${2:MPI_Datarep_conversion_function* read_conversion_fn} , ${3:MPI_Datarep_conversion_function* write_conversion_fn} , ${4:MPI_Datarep_extent_function* dtype_file_extent_fn} , ${5:void* extra_state} );
+endsnippet
+snippet MPI_Request_free
+MPI_Request_free( ${1:MPI_Request* request} );
+endsnippet
+snippet MPI_Request_get_status
+MPI_Request_get_status( ${1:MPI_Request request} , ${2:int* flag} , ${3:MPI_Status* status} );
+endsnippet
+snippet MPI_Rget
+MPI_Rget( ${1:void* origin_addr} , ${2:MPI_Count origin_count} , ${3:MPI_Datatype origin_datatype} , ${4:int target_rank} , ${5:MPI_Aint target_disp} , ${6:MPI_Count target_count} , ${7:MPI_Datatype target_datatype} , ${8:MPI_Win win} , ${9:MPI_Request* request} );
+endsnippet
+snippet MPI_Rget_accumulate
+MPI_Rget_accumulate( ${1:const void* origin_addr} , ${2:MPI_Count origin_count} , ${3:MPI_Datatype origin_datatype} , ${4:void* result_addr} , ${5:MPI_Count result_count} , ${6:MPI_Datatype result_datatype} , ${7:int target_rank} , ${8:MPI_Aint target_disp} , ${9:MPI_Count target_count} , ${10:MPI_Datatype target_datatype} , ${11:MPI_Op op} , ${12:MPI_Win win} , ${13:MPI_Request* request} );
+endsnippet
+snippet MPI_Rput
+MPI_Rput( ${1:const void* origin_addr} , ${2:MPI_Count origin_count} , ${3:MPI_Datatype origin_datatype} , ${4:int target_rank} , ${5:MPI_Aint target_disp} , ${6:MPI_Count target_count} , ${7:MPI_Datatype target_datatype} , ${8:MPI_Win win} , ${9:MPI_Request* request} );
+endsnippet
+snippet MPI_Rsend
+MPI_Rsend( ${1:const void* buf} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} );
+endsnippet
+snippet MPI_Rsend_init
+MPI_Rsend_init( ${1:const void* buf} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
+endsnippet
+snippet MPI_Scan
+MPI_Scan( ${1:const void* sendbuf} , ${2:void* recvbuf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:MPI_Comm comm} );
+endsnippet
+snippet MPI_Scan_init
+MPI_Scan_init( ${1:const void* sendbuf} , ${2:void* recvbuf} , ${3:MPI_Count count} , ${4:MPI_Datatype datatype} , ${5:MPI_Op op} , ${6:MPI_Comm comm} , ${7:MPI_Info info} , ${8:MPI_Request* request} );
+endsnippet
+snippet MPI_Scatter
+MPI_Scatter( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:MPI_Count recvcount} , ${6:MPI_Datatype recvtype} , ${7:int root} , ${8:MPI_Comm comm} );
+endsnippet
+snippet MPI_Scatter_init
+MPI_Scatter_init( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:void* recvbuf} , ${5:MPI_Count recvcount} , ${6:MPI_Datatype recvtype} , ${7:int root} , ${8:MPI_Comm comm} , ${9:MPI_Info info} , ${10:MPI_Request* request} );
+endsnippet
+snippet MPI_Scatterv
+MPI_Scatterv( ${1:const void* sendbuf} , ${2:const MPI_Count sendcounts[]} , ${3:const MPI_Aint displs[]} , ${4:MPI_Datatype sendtype} , ${5:void* recvbuf} , ${6:MPI_Count recvcount} , ${7:MPI_Datatype recvtype} , ${8:int root} , ${9:MPI_Comm comm} );
+endsnippet
+snippet MPI_Scatterv_init
+MPI_Scatterv_init( ${1:const void* sendbuf} , ${2:const MPI_Count sendcounts[]} , ${3:const MPI_Aint displs[]} , ${4:MPI_Datatype sendtype} , ${5:void* recvbuf} , ${6:MPI_Count recvcount} , ${7:MPI_Datatype recvtype} , ${8:int root} , ${9:MPI_Comm comm} , ${10:MPI_Info info} , ${11:MPI_Request* request} );
+endsnippet
+snippet MPI_Send
+MPI_Send( ${1:const void* buf} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} );
+endsnippet
+snippet MPI_Send_init
+MPI_Send_init( ${1:const void* buf} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
+endsnippet
+snippet MPI_Sendrecv
+MPI_Sendrecv( ${1:const void* sendbuf} , ${2:MPI_Count sendcount} , ${3:MPI_Datatype sendtype} , ${4:int dest} , ${5:int sendtag} , ${6:void* recvbuf} , ${7:MPI_Count recvcount} , ${8:MPI_Datatype recvtype} , ${9:int source} , ${10:int recvtag} , ${11:MPI_Comm comm} , ${12:MPI_Status* status} );
+endsnippet
+snippet MPI_Sendrecv_replace
+MPI_Sendrecv_replace( ${1:void* buf} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int sendtag} , ${6:int source} , ${7:int recvtag} , ${8:MPI_Comm comm} , ${9:MPI_Status* status} );
+endsnippet
+snippet MPI_Session_call_errhandler
+MPI_Session_call_errhandler( ${1:MPI_Session session} , ${2:int errorcode} );
+endsnippet
+snippet MPI_Session_create_errhandler
+MPI_Session_create_errhandler( ${1:MPI_Session_errhandler_function* session_errhandler_fn} , ${2:MPI_Errhandler* errhandler} );
+endsnippet
+snippet MPI_Session_finalize
+MPI_Session_finalize( ${1:MPI_Session* session} );
+endsnippet
+snippet MPI_Session_get_errhandler
+MPI_Session_get_errhandler( ${1:MPI_Session session} , ${2:MPI_Errhandler* errhandler} );
+endsnippet
+snippet MPI_Session_get_info
+MPI_Session_get_info( ${1:MPI_Session session} , ${2:MPI_Info* info_used} );
+endsnippet
+snippet MPI_Session_get_nth_pset
+MPI_Session_get_nth_pset( ${1:MPI_Session session} , ${2:MPI_Info info} , ${3:int n} , ${4:int* pset_len} , ${5:char* pset_name} );
+endsnippet
+snippet MPI_Session_get_num_psets
+MPI_Session_get_num_psets( ${1:MPI_Session session} , ${2:MPI_Info info} , ${3:int* npset_names} );
+endsnippet
+snippet MPI_Session_get_pset_info
+MPI_Session_get_pset_info( ${1:MPI_Session session} , ${2:const char* pset_name} , ${3:MPI_Info* info} );
+endsnippet
+snippet MPI_Session_init
+MPI_Session_init( ${1:MPI_Info info} , ${2:MPI_Errhandler errhandler} , ${3:MPI_Session* session} );
+endsnippet
+snippet MPI_Session_set_errhandler
+MPI_Session_set_errhandler( ${1:MPI_Session session} , ${2:MPI_Errhandler errhandler} );
+endsnippet
+snippet MPI_Ssend
+MPI_Ssend( ${1:const void* buf} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} );
+endsnippet
+snippet MPI_Ssend_init
+MPI_Ssend_init( ${1:const void* buf} , ${2:MPI_Count count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} , ${7:MPI_Request* request} );
+endsnippet
+snippet MPI_Start
+MPI_Start( ${1:MPI_Request* request} );
+endsnippet
+snippet MPI_Startall
+MPI_Startall( ${1:int count} , ${2:MPI_Request array_of_requests[]} );
+endsnippet
+snippet MPI_Status_set_cancelled
+MPI_Status_set_cancelled( ${1:MPI_Status* status} , ${2:int flag} );
+endsnippet
+snippet MPI_Status_set_elements
+MPI_Status_set_elements( ${1:MPI_Status* status} , ${2:MPI_Datatype datatype} , ${3:MPI_Count count} );
+endsnippet
+snippet MPI_Status_set_elements_x
+MPI_Status_set_elements_x( ${1:MPI_Status* status} , ${2:MPI_Datatype datatype} , ${3:MPI_Count count} );
+endsnippet
+snippet MPI_T_category_changed
+MPI_T_category_changed( ${1:int* update_number} );
+endsnippet
+snippet MPI_T_category_get_categories
+MPI_T_category_get_categories( ${1:int cat_index} , ${2:int len} , ${3:int indices[]} );
+endsnippet
+snippet MPI_T_category_get_cvars
+MPI_T_category_get_cvars( ${1:int cat_index} , ${2:int len} , ${3:int indices[]} );
+endsnippet
+snippet MPI_T_category_get_events
+MPI_T_category_get_events( ${1:int cat_index} , ${2:int len} , ${3:int indices[]} );
+endsnippet
+snippet MPI_T_category_get_index
+MPI_T_category_get_index( ${1:const char* name} , ${2:int* cat_index} );
+endsnippet
+snippet MPI_T_category_get_info
+MPI_T_category_get_info( ${1:int cat_index} , ${2:char* name} , ${3:int* name_len} , ${4:char* desc} , ${5:int* desc_len} , ${6:int* num_cvars} , ${7:int* num_pvars} , ${8:int* num_categories} );
+endsnippet
+snippet MPI_T_category_get_num
+MPI_T_category_get_num( ${1:int* num_cat} );
+endsnippet
+snippet MPI_T_category_get_num_events
+MPI_T_category_get_num_events( ${1:int cat_index} , ${2:int* num_events} );
+endsnippet
+snippet MPI_T_category_get_pvars
+MPI_T_category_get_pvars( ${1:int cat_index} , ${2:int len} , ${3:int indices[]} );
+endsnippet
+snippet MPI_T_cvar_get_index
+MPI_T_cvar_get_index( ${1:const char* name} , ${2:int* cvar_index} );
+endsnippet
+snippet MPI_T_cvar_get_info
+MPI_T_cvar_get_info( ${1:int cvar_index} , ${2:char* name} , ${3:int* name_len} , ${4:int* verbosity} , ${5:MPI_Datatype* datatype} , ${6:MPI_T_enum* enumtype} , ${7:char* desc} , ${8:int* desc_len} , ${9:int* bind} , ${10:int* scope} );
+endsnippet
+snippet MPI_T_cvar_get_num
+MPI_T_cvar_get_num( ${1:int* num_cvar} );
+endsnippet
+snippet MPI_T_cvar_handle_alloc
+MPI_T_cvar_handle_alloc( ${1:int cvar_index} , ${2:void* obj_handle} , ${3:MPI_T_cvar_handle* handle} , ${4:int* count} );
+endsnippet
+snippet MPI_T_cvar_handle_free
+MPI_T_cvar_handle_free( ${1:MPI_T_cvar_handle* handle} );
+endsnippet
+snippet MPI_T_cvar_read
+MPI_T_cvar_read( ${1:MPI_T_cvar_handle handle} , ${2:void* buf} );
+endsnippet
+snippet MPI_T_cvar_write
+MPI_T_cvar_write( ${1:MPI_T_cvar_handle handle} , ${2:const void* buf} );
+endsnippet
+snippet MPI_T_enum_get_info
+MPI_T_enum_get_info( ${1:MPI_T_enum enumtype} , ${2:int* num} , ${3:char* name} , ${4:int* name_len} );
+endsnippet
+snippet MPI_T_enum_get_item
+MPI_T_enum_get_item( ${1:MPI_T_enum enumtype} , ${2:int index} , ${3:int* value} , ${4:char* name} , ${5:int* name_len} );
+endsnippet
+snippet MPI_T_event_callback_get_info
+MPI_T_event_callback_get_info( ${1:MPI_T_event_registration event_registration} , ${2:MPI_T_cb_safety cb_safety} , ${3:MPI_Info* info_used} );
+endsnippet
+snippet MPI_T_event_callback_set_info
+MPI_T_event_callback_set_info( ${1:MPI_T_event_registration event_registration} , ${2:MPI_T_cb_safety cb_safety} , ${3:MPI_Info info} );
+endsnippet
+snippet MPI_T_event_copy
+MPI_T_event_copy( ${1:MPI_T_event_instance event_instance} , ${2:void* buffer} );
+endsnippet
+snippet MPI_T_event_get_index
+MPI_T_event_get_index( ${1:const char* name} , ${2:int* event_index} );
+endsnippet
+snippet MPI_T_event_get_info
+MPI_T_event_get_info( ${1:int event_index} , ${2:char* name} , ${3:int* name_len} , ${4:int* verbosity} , ${5:MPI_Datatype array_of_datatypes[]} , ${6:MPI_Aint array_of_displacements[]} , ${7:int* num_elements} , ${8:MPI_T_enum* enumtype} , ${9:MPI_Info* info} , ${10:char* desc} , ${11:int* desc_len} , ${12:int* bind} );
+endsnippet
+snippet MPI_T_event_get_num
+MPI_T_event_get_num( ${1:int* num_events} );
+endsnippet
+snippet MPI_T_event_get_source
+MPI_T_event_get_source( ${1:MPI_T_event_instance event_instance} , ${2:int* source_index} );
+endsnippet
+snippet MPI_T_event_get_timestamp
+MPI_T_event_get_timestamp( ${1:MPI_T_event_instance event_instance} , ${2:MPI_Count* event_timestamp} );
+endsnippet
+snippet MPI_T_event_handle_alloc
+MPI_T_event_handle_alloc( ${1:int event_index} , ${2:void* obj_handle} , ${3:MPI_Info info} , ${4:MPI_T_event_registration* event_registration} );
+endsnippet
+snippet MPI_T_event_handle_free
+MPI_T_event_handle_free( ${1:MPI_T_event_registration event_registration} , ${2:void* user_data} , ${3:MPI_T_event_free_cb_function free_cb_function} );
+endsnippet
+snippet MPI_T_event_handle_get_info
+MPI_T_event_handle_get_info( ${1:MPI_T_event_registration event_registration} , ${2:MPI_Info* info_used} );
+endsnippet
+snippet MPI_T_event_handle_set_info
+MPI_T_event_handle_set_info( ${1:MPI_T_event_registration event_registration} , ${2:MPI_Info info} );
+endsnippet
+snippet MPI_T_event_read
+MPI_T_event_read( ${1:MPI_T_event_instance event_instance} , ${2:int element_index} , ${3:void* buffer} );
+endsnippet
+snippet MPI_T_event_register_callback
+MPI_T_event_register_callback( ${1:MPI_T_event_registration event_registration} , ${2:MPI_T_cb_safety cb_safety} , ${3:MPI_Info info} , ${4:void* user_data} , ${5:MPI_T_event_cb_function event_cb_function} );
+endsnippet
+snippet MPI_T_event_set_dropped_handler
+MPI_T_event_set_dropped_handler( ${1:MPI_T_event_registration event_registration} , ${2:MPI_T_event_dropped_cb_function dropped_cb_function} );
+endsnippet
+snippet MPI_T_finalize
+MPI_T_finalize();
+endsnippet
+snippet MPI_T_init_thread
+MPI_T_init_thread( ${1:int required} , ${2:int* provided} );
+endsnippet
+snippet MPI_T_pvar_get_index
+MPI_T_pvar_get_index( ${1:const char* name} , ${2:int var_class} , ${3:int* pvar_index} );
+endsnippet
+snippet MPI_T_pvar_get_info
+MPI_T_pvar_get_info( ${1:int pvar_index} , ${2:char* name} , ${3:int* name_len} , ${4:int* verbosity} , ${5:int* var_class} , ${6:MPI_Datatype* datatype} , ${7:MPI_T_enum* enumtype} , ${8:char* desc} , ${9:int* desc_len} , ${10:int* bind} , ${11:int* readonly} , ${12:int* continuous} , ${13:int* atomic} );
+endsnippet
+snippet MPI_T_pvar_get_num
+MPI_T_pvar_get_num( ${1:int* num_pvar} );
+endsnippet
+snippet MPI_T_pvar_handle_alloc
+MPI_T_pvar_handle_alloc( ${1:MPI_T_pvar_session pe_session} , ${2:int pvar_index} , ${3:void* obj_handle} , ${4:MPI_T_pvar_handle* handle} , ${5:int* count} );
+endsnippet
+snippet MPI_T_pvar_handle_free
+MPI_T_pvar_handle_free( ${1:MPI_T_pvar_session pe_session} , ${2:MPI_T_pvar_handle* handle} );
+endsnippet
+snippet MPI_T_pvar_read
+MPI_T_pvar_read( ${1:MPI_T_pvar_session pe_session} , ${2:MPI_T_pvar_handle handle} , ${3:void* buf} );
+endsnippet
+snippet MPI_T_pvar_readreset
+MPI_T_pvar_readreset( ${1:MPI_T_pvar_session pe_session} , ${2:MPI_T_pvar_handle handle} , ${3:void* buf} );
+endsnippet
+snippet MPI_T_pvar_reset
+MPI_T_pvar_reset( ${1:MPI_T_pvar_session pe_session} , ${2:MPI_T_pvar_handle handle} );
+endsnippet
+snippet MPI_T_pvar_session_create
+MPI_T_pvar_session_create( ${1:MPI_T_pvar_session* pe_session} );
+endsnippet
+snippet MPI_T_pvar_session_free
+MPI_T_pvar_session_free( ${1:MPI_T_pvar_session* pe_session} );
+endsnippet
+snippet MPI_T_pvar_start
+MPI_T_pvar_start( ${1:MPI_T_pvar_session pe_session} , ${2:MPI_T_pvar_handle handle} );
+endsnippet
+snippet MPI_T_pvar_stop
+MPI_T_pvar_stop( ${1:MPI_T_pvar_session pe_session} , ${2:MPI_T_pvar_handle handle} );
+endsnippet
+snippet MPI_T_pvar_write
+MPI_T_pvar_write( ${1:MPI_T_pvar_session pe_session} , ${2:MPI_T_pvar_handle handle} , ${3:const void* buf} );
+endsnippet
+snippet MPI_T_source_get_info
+MPI_T_source_get_info( ${1:int source_index} , ${2:char* name} , ${3:int* name_len} , ${4:char* desc} , ${5:int* desc_len} , ${6:MPI_T_source_order* ordering} , ${7:MPI_Count* ticks_per_second} , ${8:MPI_Count* max_ticks} , ${9:MPI_Info* info} );
+endsnippet
+snippet MPI_T_source_get_num
+MPI_T_source_get_num( ${1:int* num_sources} );
+endsnippet
+snippet MPI_T_source_get_timestamp
+MPI_T_source_get_timestamp( ${1:int source_index} , ${2:MPI_Count* timestamp} );
+endsnippet
+snippet MPI_Test
+MPI_Test( ${1:MPI_Request* request} , ${2:int* flag} , ${3:MPI_Status* status} );
+endsnippet
+snippet MPI_Test_cancelled
+MPI_Test_cancelled( ${1:const MPI_Status* status} , ${2:int* flag} );
+endsnippet
+snippet MPI_Testall
+MPI_Testall( ${1:int count} , ${2:MPI_Request array_of_requests[]} , ${3:int* flag} , ${4:MPI_Status array_of_statuses[]} );
+endsnippet
+snippet MPI_Testany
+MPI_Testany( ${1:int count} , ${2:MPI_Request array_of_requests[]} , ${3:int* index} , ${4:int* flag} , ${5:MPI_Status* status} );
+endsnippet
+snippet MPI_Testsome
+MPI_Testsome( ${1:int incount} , ${2:MPI_Request array_of_requests[]} , ${3:int* outcount} , ${4:int array_of_indices[]} , ${5:MPI_Status array_of_statuses[]} );
+endsnippet
+snippet MPI_Topo_test
+MPI_Topo_test( ${1:MPI_Comm comm} , ${2:int* status} );
+endsnippet
+snippet MPI_Type_commit
+MPI_Type_commit( ${1:MPI_Datatype* datatype} );
+endsnippet
+snippet MPI_Type_contiguous
+MPI_Type_contiguous( ${1:MPI_Count count} , ${2:MPI_Datatype oldtype} , ${3:MPI_Datatype* newtype} );
+endsnippet
+snippet MPI_Type_create_darray
+MPI_Type_create_darray( ${1:int size} , ${2:int rank} , ${3:int ndims} , ${4:const MPI_Count array_of_gsizes[]} , ${5:const int array_of_distribs[]} , ${6:const int array_of_dargs[]} , ${7:const int array_of_psizes[]} , ${8:int order} , ${9:MPI_Datatype oldtype} , ${10:MPI_Datatype* newtype} );
+endsnippet
+snippet MPI_Type_create_f90_complex
+MPI_Type_create_f90_complex( ${1:int p} , ${2:int r} , ${3:MPI_Datatype* newtype} );
+endsnippet
+snippet MPI_Type_create_f90_integer
+MPI_Type_create_f90_integer( ${1:int r} , ${2:MPI_Datatype* newtype} );
+endsnippet
+snippet MPI_Type_create_f90_real
+MPI_Type_create_f90_real( ${1:int p} , ${2:int r} , ${3:MPI_Datatype* newtype} );
+endsnippet
+snippet MPI_Type_create_hindexed
+MPI_Type_create_hindexed( ${1:MPI_Count count} , ${2:const MPI_Count array_of_blocklengths[]} , ${3:const MPI_Count array_of_displacements[]} , ${4:MPI_Datatype oldtype} , ${5:MPI_Datatype* newtype} );
+endsnippet
+snippet MPI_Type_create_hindexed_block
+MPI_Type_create_hindexed_block( ${1:MPI_Count count} , ${2:MPI_Count blocklength} , ${3:const MPI_Count array_of_displacements[]} , ${4:MPI_Datatype oldtype} , ${5:MPI_Datatype* newtype} );
+endsnippet
+snippet MPI_Type_create_hvector
+MPI_Type_create_hvector( ${1:MPI_Count count} , ${2:MPI_Count blocklength} , ${3:MPI_Count stride} , ${4:MPI_Datatype oldtype} , ${5:MPI_Datatype* newtype} );
+endsnippet
+snippet MPI_Type_create_indexed_block
+MPI_Type_create_indexed_block( ${1:MPI_Count count} , ${2:MPI_Count blocklength} , ${3:const MPI_Count array_of_displacements[]} , ${4:MPI_Datatype oldtype} , ${5:MPI_Datatype* newtype} );
+endsnippet
+snippet MPI_Type_create_keyval
+MPI_Type_create_keyval( ${1:MPI_Type_copy_attr_function* type_copy_attr_fn} , ${2:MPI_Type_delete_attr_function* type_delete_attr_fn} , ${3:int* type_keyval} , ${4:void* extra_state} );
+endsnippet
+snippet MPI_Type_create_resized
+MPI_Type_create_resized( ${1:MPI_Datatype oldtype} , ${2:MPI_Count lb} , ${3:MPI_Count extent} , ${4:MPI_Datatype* newtype} );
+endsnippet
+snippet MPI_Type_create_struct
+MPI_Type_create_struct( ${1:MPI_Count count} , ${2:const MPI_Count array_of_blocklengths[]} , ${3:const MPI_Count array_of_displacements[]} , ${4:const MPI_Datatype array_of_types[]} , ${5:MPI_Datatype* newtype} );
+endsnippet
+snippet MPI_Type_create_subarray
+MPI_Type_create_subarray( ${1:int ndims} , ${2:const MPI_Count array_of_sizes[]} , ${3:const MPI_Count array_of_subsizes[]} , ${4:const MPI_Count array_of_starts[]} , ${5:int order} , ${6:MPI_Datatype oldtype} , ${7:MPI_Datatype* newtype} );
+endsnippet
+snippet MPI_Type_delete_attr
+MPI_Type_delete_attr( ${1:MPI_Datatype datatype} , ${2:int type_keyval} );
+endsnippet
+snippet MPI_Type_dup
+MPI_Type_dup( ${1:MPI_Datatype oldtype} , ${2:MPI_Datatype* newtype} );
+endsnippet
+snippet MPI_Type_free
+MPI_Type_free( ${1:MPI_Datatype* datatype} );
+endsnippet
+snippet MPI_Type_free_keyval
+MPI_Type_free_keyval( ${1:int* type_keyval} );
+endsnippet
+snippet MPI_Type_get_attr
+MPI_Type_get_attr( ${1:MPI_Datatype datatype} , ${2:int type_keyval} , ${3:void* attribute_val} , ${4:int* flag} );
+endsnippet
+snippet MPI_Type_get_contents
+MPI_Type_get_contents( ${1:MPI_Datatype datatype} , ${2:MPI_Count max_integers} , ${3:MPI_Count max_addresses} , ${4:MPI_Count max_large_counts} , ${5:MPI_Count max_datatypes} , ${6:int array_of_integers[]} , ${7:MPI_Aint array_of_addresses[]} , ${8:MPI_Count array_of_large_counts[]} , ${9:MPI_Datatype array_of_datatypes[]} );
+endsnippet
+snippet MPI_Type_get_envelope
+MPI_Type_get_envelope( ${1:MPI_Datatype datatype} , ${2:MPI_Count* num_integers} , ${3:MPI_Count* num_addresses} , ${4:MPI_Count* num_large_counts} , ${5:MPI_Count* num_datatypes} , ${6:int* combiner} );
+endsnippet
+snippet MPI_Type_get_extent
+MPI_Type_get_extent( ${1:MPI_Datatype datatype} , ${2:MPI_Count* lb} , ${3:MPI_Count* extent} );
+endsnippet
+snippet MPI_Type_get_extent_x
+MPI_Type_get_extent_x( ${1:MPI_Datatype datatype} , ${2:MPI_Count* lb} , ${3:MPI_Count* extent} );
+endsnippet
+snippet MPI_Type_get_name
+MPI_Type_get_name( ${1:MPI_Datatype datatype} , ${2:char* type_name} , ${3:int* resultlen} );
+endsnippet
+snippet MPI_Type_get_true_extent
+MPI_Type_get_true_extent( ${1:MPI_Datatype datatype} , ${2:MPI_Count* true_lb} , ${3:MPI_Count* true_extent} );
+endsnippet
+snippet MPI_Type_get_true_extent_x
+MPI_Type_get_true_extent_x( ${1:MPI_Datatype datatype} , ${2:MPI_Count* true_lb} , ${3:MPI_Count* true_extent} );
+endsnippet
+snippet MPI_Type_indexed
+MPI_Type_indexed( ${1:MPI_Count count} , ${2:const MPI_Count array_of_blocklengths[]} , ${3:const MPI_Count array_of_displacements[]} , ${4:MPI_Datatype oldtype} , ${5:MPI_Datatype* newtype} );
+endsnippet
+snippet MPI_Type_match_size
+MPI_Type_match_size( ${1:int typeclass} , ${2:int size} , ${3:MPI_Datatype* datatype} );
+endsnippet
+snippet MPI_Type_set_attr
+MPI_Type_set_attr( ${1:MPI_Datatype datatype} , ${2:int type_keyval} , ${3:void* attribute_val} );
+endsnippet
+snippet MPI_Type_set_name
+MPI_Type_set_name( ${1:MPI_Datatype datatype} , ${2:const char* type_name} );
+endsnippet
+snippet MPI_Type_size
+MPI_Type_size( ${1:MPI_Datatype datatype} , ${2:MPI_Count* size} );
+endsnippet
+snippet MPI_Type_size_x
+MPI_Type_size_x( ${1:MPI_Datatype datatype} , ${2:MPI_Count* size} );
+endsnippet
+snippet MPI_Type_vector
+MPI_Type_vector( ${1:MPI_Count count} , ${2:MPI_Count blocklength} , ${3:MPI_Count stride} , ${4:MPI_Datatype oldtype} , ${5:MPI_Datatype* newtype} );
+endsnippet
+snippet MPI_Unpack
+MPI_Unpack( ${1:const void* inbuf} , ${2:MPI_Count insize} , ${3:MPI_Count* position} , ${4:void* outbuf} , ${5:MPI_Count outcount} , ${6:MPI_Datatype datatype} , ${7:MPI_Comm comm} );
+endsnippet
+snippet MPI_Unpack_external
+MPI_Unpack_external( ${1:const char datarep[]} , ${2:const void* inbuf} , ${3:MPI_Count insize} , ${4:MPI_Count* position} , ${5:void* outbuf} , ${6:MPI_Count outcount} , ${7:MPI_Datatype datatype} );
+endsnippet
+snippet MPI_Unpublish_name
+MPI_Unpublish_name( ${1:const char* service_name} , ${2:MPI_Info info} , ${3:const char* port_name} );
+endsnippet
+snippet MPI_Wait
+MPI_Wait( ${1:MPI_Request* request} , ${2:MPI_Status* status} );
+endsnippet
+snippet MPI_Waitall
+MPI_Waitall( ${1:int count} , ${2:MPI_Request array_of_requests[]} , ${3:MPI_Status array_of_statuses[]} );
+endsnippet
+snippet MPI_Waitany
+MPI_Waitany( ${1:int count} , ${2:MPI_Request array_of_requests[]} , ${3:int* index} , ${4:MPI_Status* status} );
+endsnippet
+snippet MPI_Waitsome
+MPI_Waitsome( ${1:int incount} , ${2:MPI_Request array_of_requests[]} , ${3:int* outcount} , ${4:int array_of_indices[]} , ${5:MPI_Status array_of_statuses[]} );
+endsnippet
+snippet MPI_Win_allocate
+MPI_Win_allocate( ${1:MPI_Aint size} , ${2:MPI_Aint disp_unit} , ${3:MPI_Info info} , ${4:MPI_Comm comm} , ${5:void* baseptr} , ${6:MPI_Win* win} );
+endsnippet
+snippet MPI_Win_allocate_shared
+MPI_Win_allocate_shared( ${1:MPI_Aint size} , ${2:MPI_Aint disp_unit} , ${3:MPI_Info info} , ${4:MPI_Comm comm} , ${5:void* baseptr} , ${6:MPI_Win* win} );
+endsnippet
+snippet MPI_Win_attach
+MPI_Win_attach( ${1:MPI_Win win} , ${2:void* base} , ${3:MPI_Aint size} );
+endsnippet
+snippet MPI_Win_call_errhandler
+MPI_Win_call_errhandler( ${1:MPI_Win win} , ${2:int errorcode} );
+endsnippet
+snippet MPI_Win_complete
+MPI_Win_complete( ${1:MPI_Win win} );
+endsnippet
+snippet MPI_Win_create
+MPI_Win_create( ${1:void* base} , ${2:MPI_Aint size} , ${3:MPI_Aint disp_unit} , ${4:MPI_Info info} , ${5:MPI_Comm comm} , ${6:MPI_Win* win} );
+endsnippet
+snippet MPI_Win_create_dynamic
+MPI_Win_create_dynamic( ${1:MPI_Info info} , ${2:MPI_Comm comm} , ${3:MPI_Win* win} );
+endsnippet
+snippet MPI_Win_create_errhandler
+MPI_Win_create_errhandler( ${1:MPI_Win_errhandler_function* win_errhandler_fn} , ${2:MPI_Errhandler* errhandler} );
+endsnippet
+snippet MPI_Win_create_keyval
+MPI_Win_create_keyval( ${1:MPI_Win_copy_attr_function* win_copy_attr_fn} , ${2:MPI_Win_delete_attr_function* win_delete_attr_fn} , ${3:int* win_keyval} , ${4:void* extra_state} );
+endsnippet
+snippet MPI_Win_delete_attr
+MPI_Win_delete_attr( ${1:MPI_Win win} , ${2:int win_keyval} );
+endsnippet
+snippet MPI_Win_detach
+MPI_Win_detach( ${1:MPI_Win win} , ${2:const void* base} );
+endsnippet
+snippet MPI_Win_fence
+MPI_Win_fence( ${1:int assert} , ${2:MPI_Win win} );
+endsnippet
+snippet MPI_Win_flush
+MPI_Win_flush( ${1:int rank} , ${2:MPI_Win win} );
+endsnippet
+snippet MPI_Win_flush_all
+MPI_Win_flush_all( ${1:MPI_Win win} );
+endsnippet
+snippet MPI_Win_flush_local
+MPI_Win_flush_local( ${1:int rank} , ${2:MPI_Win win} );
+endsnippet
+snippet MPI_Win_flush_local_all
+MPI_Win_flush_local_all( ${1:MPI_Win win} );
+endsnippet
+snippet MPI_Win_free
+MPI_Win_free( ${1:MPI_Win* win} );
+endsnippet
+snippet MPI_Win_free_keyval
+MPI_Win_free_keyval( ${1:int* win_keyval} );
+endsnippet
+snippet MPI_Win_get_attr
+MPI_Win_get_attr( ${1:MPI_Win win} , ${2:int win_keyval} , ${3:void* attribute_val} , ${4:int* flag} );
+endsnippet
+snippet MPI_Win_get_errhandler
+MPI_Win_get_errhandler( ${1:MPI_Win win} , ${2:MPI_Errhandler* errhandler} );
+endsnippet
+snippet MPI_Win_get_group
+MPI_Win_get_group( ${1:MPI_Win win} , ${2:MPI_Group* group} );
+endsnippet
+snippet MPI_Win_get_info
+MPI_Win_get_info( ${1:MPI_Win win} , ${2:MPI_Info* info_used} );
+endsnippet
+snippet MPI_Win_get_name
+MPI_Win_get_name( ${1:MPI_Win win} , ${2:char* win_name} , ${3:int* resultlen} );
+endsnippet
+snippet MPI_Win_lock
+MPI_Win_lock( ${1:int lock_type} , ${2:int rank} , ${3:int assert} , ${4:MPI_Win win} );
+endsnippet
+snippet MPI_Win_lock_all
+MPI_Win_lock_all( ${1:int assert} , ${2:MPI_Win win} );
+endsnippet
+snippet MPI_Win_post
+MPI_Win_post( ${1:MPI_Group group} , ${2:int assert} , ${3:MPI_Win win} );
+endsnippet
+snippet MPI_Win_set_attr
+MPI_Win_set_attr( ${1:MPI_Win win} , ${2:int win_keyval} , ${3:void* attribute_val} );
+endsnippet
+snippet MPI_Win_set_errhandler
+MPI_Win_set_errhandler( ${1:MPI_Win win} , ${2:MPI_Errhandler errhandler} );
+endsnippet
+snippet MPI_Win_set_info
+MPI_Win_set_info( ${1:MPI_Win win} , ${2:MPI_Info info} );
+endsnippet
+snippet MPI_Win_set_name
+MPI_Win_set_name( ${1:MPI_Win win} , ${2:const char* win_name} );
+endsnippet
+snippet MPI_Win_shared_query
+MPI_Win_shared_query( ${1:MPI_Win win} , ${2:int rank} , ${3:MPI_Aint* size} , ${4:MPI_Aint* disp_unit} , ${5:void* baseptr} );
+endsnippet
+snippet MPI_Win_start
+MPI_Win_start( ${1:MPI_Group group} , ${2:int assert} , ${3:MPI_Win win} );
+endsnippet
+snippet MPI_Win_sync
+MPI_Win_sync( ${1:MPI_Win win} );
+endsnippet
 snippet MPI_Win_test
 MPI_Win_test( ${1:MPI_Win win} , ${2:int* flag} );
 endsnippet
-snippet MPI_Type_create_hindexed
-MPI_Type_create_hindexed( ${1:int count} , ${2:int array_of_blocklengths[]} , ${3:MPI_Aint array_of_displacements[]} , ${4:MPI_Datatype oldtype} , ${5:MPI_Datatype* newtype} );
+snippet MPI_Win_unlock
+MPI_Win_unlock( ${1:int rank} , ${2:MPI_Win win} );
 endsnippet
-snippet MPI_Type_match_size
-MPI_Type_match_size( ${1:int typeclass} , ${2:int size} , ${3:MPI_Datatype* type} );
+snippet MPI_Win_unlock_all
+MPI_Win_unlock_all( ${1:MPI_Win win} );
 endsnippet
-snippet MPI_Send
-MPI_Send( ${1:void* buf} , ${2:int count} , ${3:MPI_Datatype datatype} , ${4:int dest} , ${5:int tag} , ${6:MPI_Comm comm} );
+snippet MPI_Win_wait
+MPI_Win_wait( ${1:MPI_Win win} );
+endsnippet
+snippet MPI_Wtick
+MPI_Wtick();
+endsnippet
+snippet MPI_Wtime
+MPI_Wtime();
 endsnippet
 
 snippet mainmpi
@@ -851,7 +1361,7 @@ int main( int argc, char *argv[])
 	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 	MPI_Comm_size(MPI_COMM_WORLD, &size);
 
-        ${1:printf("Rank: %d/%d\n", rank, size);}
+	${1:printf("Rank: %d/%d\n", rank, size);}
 
 	MPI_Finalize();
 

--- a/gen-vscode.py
+++ b/gen-vscode.py
@@ -35,7 +35,7 @@ for f in mpi_interface:
 			idx=-1
 		if idx!=-1:
 			array=ctype[idx:]
-   			ctype=ctype[0:idx]
+			ctype=ctype[0:idx]
 		IFACE+=" ${" + str(i+1) + ":" + ctype + " " + name + array + "}"
 		if i < (len(fd) - 1):
 			IFACE += ","

--- a/gen.py
+++ b/gen.py
@@ -33,7 +33,7 @@ for f in mpi_interface:
 			idx=-1
 		if idx!=-1:
 			array=ctype[idx:]
-   			ctype=ctype[0:idx]
+			ctype=ctype[0:idx]
 		IFACE+=" ${" + str(i+1) + ":" + ctype + " " + name + array + "} "
 		if i < (len(fd) - 1):
 			IFACE += ","

--- a/mpi.json
+++ b/mpi.json
@@ -1,7 +1,4 @@
 {
-    "MPI_Finalize":
-    [
-    ],
     "MPI_Abort": [
         [
             "MPI_Comm",
@@ -14,11 +11,11 @@
     ],
     "MPI_Accumulate": [
         [
-            "void*",
+            "const void*",
             "origin_addr"
         ],
         [
-            "int",
+            "MPI_Count",
             "origin_count"
         ],
         [
@@ -34,7 +31,7 @@
             "target_disp"
         ],
         [
-            "int",
+            "MPI_Count",
             "target_count"
         ],
         [
@@ -72,27 +69,37 @@
             "errorcode"
         ],
         [
-            "char*",
+            "const char*",
             "string"
         ]
     ],
-    "MPI_Address": [
+    "MPI_Aint_add": [
         [
-            "void*",
-            "location"
+            "MPI_Aint",
+            "base"
         ],
         [
-            "MPI_Aint*",
-            "address"
+            "MPI_Aint",
+            "disp"
+        ]
+    ],
+    "MPI_Aint_diff": [
+        [
+            "MPI_Aint",
+            "addr1"
+        ],
+        [
+            "MPI_Aint",
+            "addr2"
         ]
     ],
     "MPI_Allgather": [
         [
-            "void*",
+            "const void*",
             "sendbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "sendcount"
         ],
         [
@@ -104,7 +111,7 @@
             "recvbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "recvcount"
         ],
         [
@@ -116,13 +123,13 @@
             "comm"
         ]
     ],
-    "MPI_Allgatherv": [
+    "MPI_Allgather_init": [
         [
-            "void*",
+            "const void*",
             "sendbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "sendcount"
         ],
         [
@@ -134,14 +141,8 @@
             "recvbuf"
         ],
         [
-            "int[]",
-            "recvcounts",
-			"*"
-        ],
-        [
-            "int[]",
-            "displs",
-			"*"
+            "MPI_Count",
+            "recvcount"
         ],
         [
             "MPI_Datatype",
@@ -150,6 +151,90 @@
         [
             "MPI_Comm",
             "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Allgatherv": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "displs"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ]
+    ],
+    "MPI_Allgatherv_init": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "displs"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
         ]
     ],
     "MPI_Alloc_mem": [
@@ -168,7 +253,7 @@
     ],
     "MPI_Allreduce": [
         [
-            "void*",
+            "const void*",
             "sendbuf"
         ],
         [
@@ -176,7 +261,7 @@
             "recvbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -192,13 +277,47 @@
             "comm"
         ]
     ],
-    "MPI_Alltoall": [
+    "MPI_Allreduce_init": [
         [
-            "void*",
+            "const void*",
             "sendbuf"
         ],
         [
-            "int",
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Op",
+            "op"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Alltoall": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
             "sendcount"
         ],
         [
@@ -210,7 +329,7 @@
             "recvbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "recvcount"
         ],
         [
@@ -222,20 +341,14 @@
             "comm"
         ]
     ],
-    "MPI_Alltoallv": [
+    "MPI_Alltoall_init": [
         [
-            "void*",
+            "const void*",
             "sendbuf"
         ],
         [
-            "int[]",
-            "sendcounts",
-			"*"
-        ],
-        [
-            "int[]",
-            "sdispls",
-			"*"
+            "MPI_Count",
+            "sendcount"
         ],
         [
             "MPI_Datatype",
@@ -246,14 +359,54 @@
             "recvbuf"
         ],
         [
-            "int[]",
-            "recvcounts",
-			"*"
+            "MPI_Count",
+            "recvcount"
         ],
         [
-            "int[]",
-            "rdispls",
-			"*"
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Alltoallv": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "sendcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "sdispls"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "rdispls"
         ],
         [
             "MPI_Datatype",
@@ -264,48 +417,134 @@
             "comm"
         ]
     ],
-    "MPI_Alltoallw": [
+    "MPI_Alltoallv_init": [
         [
-            "void*",
+            "const void*",
             "sendbuf"
         ],
         [
-            "int[]",
-            "sendcounts",
-			"*"
+            "const MPI_Count[]",
+            "sendcounts"
         ],
         [
-            "int[]",
-            "sdispls",
-			"*"
+            "const MPI_Aint[]",
+            "sdispls"
         ],
         [
-            "MPI_Datatype[]",
-            "sendtypes",
-			"*"
+            "MPI_Datatype",
+            "sendtype"
         ],
         [
             "void*",
             "recvbuf"
         ],
         [
-            "int[]",
-            "recvcounts",
-			"*"
+            "const MPI_Count[]",
+            "recvcounts"
         ],
         [
-            "int[]",
-            "rdispls",
-			"*"
+            "const MPI_Aint[]",
+            "rdispls"
         ],
         [
-            "MPI_Datatype[]",
-            "recvtypes",
-			"*"
+            "MPI_Datatype",
+            "recvtype"
         ],
         [
             "MPI_Comm",
             "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Alltoallw": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "sendcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "sdispls"
+        ],
+        [
+            "const MPI_Datatype[]",
+            "sendtypes"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "rdispls"
+        ],
+        [
+            "const MPI_Datatype[]",
+            "recvtypes"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ]
+    ],
+    "MPI_Alltoallw_init": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "sendcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "sdispls"
+        ],
+        [
+            "const MPI_Datatype[]",
+            "sendtypes"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "rdispls"
+        ],
+        [
+            "const MPI_Datatype[]",
+            "recvtypes"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
         ]
     ],
     "MPI_Attr_delete": [
@@ -356,13 +595,27 @@
             "comm"
         ]
     ],
+    "MPI_Barrier_init": [
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
     "MPI_Bcast": [
         [
             "void*",
             "buffer"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -378,13 +631,43 @@
             "comm"
         ]
     ],
-    "MPI_Bsend": [
+    "MPI_Bcast_init": [
         [
             "void*",
-            "buf"
+            "buffer"
+        ],
+        [
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
         ],
         [
             "int",
+            "root"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Bsend": [
+        [
+            "const void*",
+            "buf"
+        ],
+        [
+            "MPI_Count",
             "count"
         ],
         [
@@ -406,11 +689,11 @@
     ],
     "MPI_Bsend_init": [
         [
-            "void*",
+            "const void*",
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -440,17 +723,17 @@
             "buffer"
         ],
         [
-            "int",
+            "MPI_Count",
             "size"
         ]
     ],
     "MPI_Buffer_detach": [
         [
             "void*",
-            "buffer"
+            "buffer_addr"
         ],
         [
-            "int*",
+            "MPI_Count*",
             "size"
         ]
     ],
@@ -475,28 +758,25 @@
         ],
         [
             "int[]",
-            "coords",
-			"maxdims"
+            "coords"
         ]
     ],
     "MPI_Cart_create": [
         [
             "MPI_Comm",
-            "old_comm"
+            "comm_old"
         ],
         [
             "int",
             "ndims"
         ],
         [
-            "int[]",
-            "dims",
-			"ndims"
+            "const int[]",
+            "dims"
         ],
         [
-            "int[]",
-            "periods",
-			"ndims"
+            "const int[]",
+            "periods"
         ],
         [
             "int",
@@ -518,18 +798,15 @@
         ],
         [
             "int[]",
-            "dims",
-			"maxdims"
+            "dims"
         ],
         [
             "int[]",
-            "periods",
-			"maxdims"
+            "periods"
         ],
         [
             "int[]",
-            "coords",
-			"maxdims"
+            "coords"
         ]
     ],
     "MPI_Cart_map": [
@@ -542,14 +819,12 @@
             "ndims"
         ],
         [
-            "int[]",
-            "dims",
-			"ndims"
+            "const int[]",
+            "dims"
         ],
         [
-            "int[]",
-            "periods",
-			"ndims"
+            "const int[]",
+            "periods"
         ],
         [
             "int*",
@@ -562,9 +837,8 @@
             "comm"
         ],
         [
-            "int[]",
-            "coords",
-			"*"
+            "const int[]",
+            "coords"
         ],
         [
             "int*",
@@ -599,13 +873,12 @@
             "comm"
         ],
         [
-            "int[]",
-            "remain_dims",
-			"*"
+            "const int[]",
+            "remain_dims"
         ],
         [
             "MPI_Comm*",
-            "new_comm"
+            "newcomm"
         ]
     ],
     "MPI_Cartdim_get": [
@@ -620,13 +893,13 @@
     ],
     "MPI_Close_port": [
         [
-            "char*",
+            "const char*",
             "port_name"
         ]
     ],
     "MPI_Comm_accept": [
         [
-            "char*",
+            "const char*",
             "port_name"
         ],
         [
@@ -672,7 +945,7 @@
     ],
     "MPI_Comm_connect": [
         [
-            "char*",
+            "const char*",
             "port_name"
         ],
         [
@@ -709,11 +982,51 @@
     "MPI_Comm_create_errhandler": [
         [
             "MPI_Comm_errhandler_function*",
-            "function"
+            "comm_errhandler_fn"
         ],
         [
             "MPI_Errhandler*",
             "errhandler"
+        ]
+    ],
+    "MPI_Comm_create_from_group": [
+        [
+            "MPI_Group",
+            "group"
+        ],
+        [
+            "const char*",
+            "stringtag"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Errhandler",
+            "errhandler"
+        ],
+        [
+            "MPI_Comm*",
+            "newcomm"
+        ]
+    ],
+    "MPI_Comm_create_group": [
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Group",
+            "group"
+        ],
+        [
+            "int",
+            "tag"
+        ],
+        [
+            "MPI_Comm*",
+            "newcomm"
         ]
     ],
     "MPI_Comm_create_keyval": [
@@ -760,6 +1073,20 @@
             "newcomm"
         ]
     ],
+    "MPI_Comm_dup_with_info": [
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Comm*",
+            "newcomm"
+        ]
+    ],
     "MPI_Comm_free": [
         [
             "MPI_Comm*",
@@ -797,7 +1124,17 @@
         ],
         [
             "MPI_Errhandler*",
-            "erhandler"
+            "errhandler"
+        ]
+    ],
+    "MPI_Comm_get_info": [
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info*",
+            "info_used"
         ]
     ],
     "MPI_Comm_get_name": [
@@ -828,6 +1165,38 @@
         [
             "MPI_Group*",
             "group"
+        ]
+    ],
+    "MPI_Comm_idup": [
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Comm*",
+            "newcomm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Comm_idup_with_info": [
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Comm*",
+            "newcomm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
         ]
     ],
     "MPI_Comm_join": [
@@ -894,13 +1263,23 @@
             "errhandler"
         ]
     ],
+    "MPI_Comm_set_info": [
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ]
+    ],
     "MPI_Comm_set_name": [
         [
             "MPI_Comm",
             "comm"
         ],
         [
-            "char*",
+            "const char*",
             "comm_name"
         ]
     ],
@@ -912,6 +1291,78 @@
         [
             "int*",
             "size"
+        ]
+    ],
+    "MPI_Comm_spawn": [
+        [
+            "const char*",
+            "command"
+        ],
+        [
+            "char*[]",
+            "argv"
+        ],
+        [
+            "int",
+            "maxprocs"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "int",
+            "root"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Comm*",
+            "intercomm"
+        ],
+        [
+            "int[]",
+            "array_of_errcodes"
+        ]
+    ],
+    "MPI_Comm_spawn_multiple": [
+        [
+            "int",
+            "count"
+        ],
+        [
+            "char*[]",
+            "array_of_commands"
+        ],
+        [
+            "char**[]",
+            "array_of_argv"
+        ],
+        [
+            "const int[]",
+            "array_of_maxprocs"
+        ],
+        [
+            "const MPI_Info[]",
+            "array_of_info"
+        ],
+        [
+            "int",
+            "root"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Comm*",
+            "intercomm"
+        ],
+        [
+            "int[]",
+            "array_of_errcodes"
         ]
     ],
     "MPI_Comm_split": [
@@ -932,6 +1383,28 @@
             "newcomm"
         ]
     ],
+    "MPI_Comm_split_type": [
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "int",
+            "split_type"
+        ],
+        [
+            "int",
+            "key"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Comm*",
+            "newcomm"
+        ]
+    ],
     "MPI_Comm_test_inter": [
         [
             "MPI_Comm",
@@ -940,6 +1413,36 @@
         [
             "int*",
             "flag"
+        ]
+    ],
+    "MPI_Compare_and_swap": [
+        [
+            "const void*",
+            "origin_addr"
+        ],
+        [
+            "const void*",
+            "compare_addr"
+        ],
+        [
+            "void*",
+            "result_addr"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "int",
+            "target_rank"
+        ],
+        [
+            "MPI_Aint",
+            "target_disp"
+        ],
+        [
+            "MPI_Win",
+            "win"
         ]
     ],
     "MPI_Dims_create": [
@@ -953,43 +1456,140 @@
         ],
         [
             "int[]",
-            "dims",
-			"ndims"
+            "dims"
         ]
     ],
-    "MPI_Errhandler_create": [
+    "MPI_Dist_graph_create": [
         [
-            "MPI_Handler_function*",
-            "function"
+            "MPI_Comm",
+            "comm_old"
         ],
         [
-            "MPI_Errhandler*",
-            "errhandler"
+            "int",
+            "n"
+        ],
+        [
+            "const int[]",
+            "sources"
+        ],
+        [
+            "const int[]",
+            "degrees"
+        ],
+        [
+            "const int[]",
+            "destinations"
+        ],
+        [
+            "const int[]",
+            "weights"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "int",
+            "reorder"
+        ],
+        [
+            "MPI_Comm*",
+            "comm_dist_graph"
+        ]
+    ],
+    "MPI_Dist_graph_create_adjacent": [
+        [
+            "MPI_Comm",
+            "comm_old"
+        ],
+        [
+            "int",
+            "indegree"
+        ],
+        [
+            "const int[]",
+            "sources"
+        ],
+        [
+            "const int[]",
+            "sourceweights"
+        ],
+        [
+            "int",
+            "outdegree"
+        ],
+        [
+            "const int[]",
+            "destinations"
+        ],
+        [
+            "const int[]",
+            "destweights"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "int",
+            "reorder"
+        ],
+        [
+            "MPI_Comm*",
+            "comm_dist_graph"
+        ]
+    ],
+    "MPI_Dist_graph_neighbors": [
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "int",
+            "maxindegree"
+        ],
+        [
+            "int[]",
+            "sources"
+        ],
+        [
+            "int[]",
+            "sourceweights"
+        ],
+        [
+            "int",
+            "maxoutdegree"
+        ],
+        [
+            "int[]",
+            "destinations"
+        ],
+        [
+            "int[]",
+            "destweights"
+        ]
+    ],
+    "MPI_Dist_graph_neighbors_count": [
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "int*",
+            "indegree"
+        ],
+        [
+            "int*",
+            "outdegree"
+        ],
+        [
+            "int*",
+            "weighted"
         ]
     ],
     "MPI_Errhandler_free": [
         [
             "MPI_Errhandler*",
-            "errhandler"
-        ]
-    ],
-    "MPI_Errhandler_get": [
-        [
-            "MPI_Comm",
-            "comm"
-        ],
-        [
-            "MPI_Errhandler*",
-            "errhandler"
-        ]
-    ],
-    "MPI_Errhandler_set": [
-        [
-            "MPI_Comm",
-            "comm"
-        ],
-        [
-            "MPI_Errhandler",
             "errhandler"
         ]
     ],
@@ -1019,7 +1619,7 @@
     ],
     "MPI_Exscan": [
         [
-            "void*",
+            "const void*",
             "sendbuf"
         ],
         [
@@ -1027,7 +1627,7 @@
             "recvbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1043,6 +1643,80 @@
             "comm"
         ]
     ],
+    "MPI_Exscan_init": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Op",
+            "op"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Fetch_and_op": [
+        [
+            "const void*",
+            "origin_addr"
+        ],
+        [
+            "void*",
+            "result_addr"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "int",
+            "target_rank"
+        ],
+        [
+            "MPI_Aint",
+            "target_disp"
+        ],
+        [
+            "MPI_Op",
+            "op"
+        ],
+        [
+            "MPI_Win",
+            "win"
+        ]
+    ],
+    "MPI_File_call_errhandler": [
+        [
+            "MPI_File",
+            "fh"
+        ],
+        [
+            "int",
+            "errorcode"
+        ]
+    ],
     "MPI_File_close": [
         [
             "MPI_File*",
@@ -1052,7 +1726,7 @@
     "MPI_File_create_errhandler": [
         [
             "MPI_File_errhandler_function*",
-            "function"
+            "file_errhandler_fn"
         ],
         [
             "MPI_Errhandler*",
@@ -1061,7 +1735,7 @@
     ],
     "MPI_File_delete": [
         [
-            "char*",
+            "const char*",
             "filename"
         ],
         [
@@ -1173,7 +1847,7 @@
             "datatype"
         ],
         [
-            "MPI_Aint*",
+            "MPI_Count*",
             "extent"
         ]
     ],
@@ -1209,7 +1883,29 @@
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_File_iread_all": [
+        [
+            "MPI_File",
+            "fh"
+        ],
+        [
+            "void*",
+            "buf"
+        ],
+        [
+            "MPI_Count",
             "count"
         ],
         [
@@ -1235,7 +1931,33 @@
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_File_iread_at_all": [
+        [
+            "MPI_File",
+            "fh"
+        ],
+        [
+            "MPI_Offset",
+            "offset"
+        ],
+        [
+            "void*",
+            "buf"
+        ],
+        [
+            "MPI_Count",
             "count"
         ],
         [
@@ -1257,7 +1979,7 @@
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1275,11 +1997,33 @@
             "fh"
         ],
         [
-            "void*",
+            "const void*",
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_File_iwrite_all": [
+        [
+            "MPI_File",
+            "fh"
+        ],
+        [
+            "const void*",
+            "buf"
+        ],
+        [
+            "MPI_Count",
             "count"
         ],
         [
@@ -1301,11 +2045,37 @@
             "offset"
         ],
         [
-            "void*",
+            "const void*",
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_File_iwrite_at_all": [
+        [
+            "MPI_File",
+            "fh"
+        ],
+        [
+            "MPI_Offset",
+            "offset"
+        ],
+        [
+            "const void*",
+            "buf"
+        ],
+        [
+            "MPI_Count",
             "count"
         ],
         [
@@ -1323,11 +2093,11 @@
             "fh"
         ],
         [
-            "void*",
+            "const void*",
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1345,7 +2115,7 @@
             "comm"
         ],
         [
-            "char*",
+            "const char*",
             "filename"
         ],
         [
@@ -1381,7 +2151,7 @@
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1403,7 +2173,7 @@
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1425,7 +2195,7 @@
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1461,7 +2231,7 @@
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1487,7 +2257,7 @@
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1513,7 +2283,7 @@
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1545,7 +2315,7 @@
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1567,7 +2337,7 @@
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1599,7 +2369,7 @@
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1697,7 +2467,7 @@
             "filetype"
         ],
         [
-            "char*",
+            "const char*",
             "datarep"
         ],
         [
@@ -1717,11 +2487,11 @@
             "fh"
         ],
         [
-            "void*",
+            "const void*",
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1739,11 +2509,11 @@
             "fh"
         ],
         [
-            "void*",
+            "const void*",
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1761,11 +2531,11 @@
             "fh"
         ],
         [
-            "void*",
+            "const void*",
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1779,7 +2549,7 @@
             "fh"
         ],
         [
-            "void*",
+            "const void*",
             "buf"
         ],
         [
@@ -1797,11 +2567,11 @@
             "offset"
         ],
         [
-            "void*",
+            "const void*",
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1823,11 +2593,11 @@
             "offset"
         ],
         [
-            "void*",
+            "const void*",
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1849,11 +2619,11 @@
             "offset"
         ],
         [
-            "void*",
+            "const void*",
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1867,7 +2637,7 @@
             "fh"
         ],
         [
-            "void*",
+            "const void*",
             "buf"
         ],
         [
@@ -1881,11 +2651,11 @@
             "fh"
         ],
         [
-            "void*",
+            "const void*",
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1903,11 +2673,11 @@
             "fh"
         ],
         [
-            "void*",
+            "const void*",
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1921,7 +2691,7 @@
             "fh"
         ],
         [
-            "void*",
+            "const void*",
             "buf"
         ],
         [
@@ -1935,11 +2705,11 @@
             "fh"
         ],
         [
-            "void*",
+            "const void*",
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -1966,11 +2736,11 @@
     ],
     "MPI_Gather": [
         [
-            "void*",
+            "const void*",
             "sendbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "sendcount"
         ],
         [
@@ -1982,7 +2752,7 @@
             "recvbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "recvcount"
         ],
         [
@@ -1998,13 +2768,13 @@
             "comm"
         ]
     ],
-    "MPI_Gatherv": [
+    "MPI_Gather_init": [
         [
-            "void*",
+            "const void*",
             "sendbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "sendcount"
         ],
         [
@@ -2016,14 +2786,54 @@
             "recvbuf"
         ],
         [
-            "int[]",
-            "recvcounts",
-			"*"
+            "MPI_Count",
+            "recvcount"
         ],
         [
-            "int[]",
-            "displs",
-			"*"
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "int",
+            "root"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Gatherv": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "displs"
         ],
         [
             "MPI_Datatype",
@@ -2038,13 +2848,59 @@
             "comm"
         ]
     ],
+    "MPI_Gatherv_init": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "displs"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "int",
+            "root"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
     "MPI_Get": [
         [
             "void*",
             "origin_addr"
         ],
         [
-            "int",
+            "MPI_Count",
             "origin_count"
         ],
         [
@@ -2060,7 +2916,7 @@
             "target_disp"
         ],
         [
-            "int",
+            "MPI_Count",
             "target_count"
         ],
         [
@@ -2072,9 +2928,59 @@
             "win"
         ]
     ],
-    "MPI_Get_address": [
+    "MPI_Get_accumulate": [
+        [
+            "const void*",
+            "origin_addr"
+        ],
+        [
+            "MPI_Count",
+            "origin_count"
+        ],
+        [
+            "MPI_Datatype",
+            "origin_datatype"
+        ],
         [
             "void*",
+            "result_addr"
+        ],
+        [
+            "MPI_Count",
+            "result_count"
+        ],
+        [
+            "MPI_Datatype",
+            "result_datatype"
+        ],
+        [
+            "int",
+            "target_rank"
+        ],
+        [
+            "MPI_Aint",
+            "target_disp"
+        ],
+        [
+            "MPI_Count",
+            "target_count"
+        ],
+        [
+            "MPI_Datatype",
+            "target_datatype"
+        ],
+        [
+            "MPI_Op",
+            "op"
+        ],
+        [
+            "MPI_Win",
+            "win"
+        ]
+    ],
+    "MPI_Get_address": [
+        [
+            "const void*",
             "location"
         ],
         [
@@ -2084,7 +2990,7 @@
     ],
     "MPI_Get_count": [
         [
-            "MPI_Status*",
+            "const MPI_Status*",
             "status"
         ],
         [
@@ -2092,13 +2998,13 @@
             "datatype"
         ],
         [
-            "int*",
+            "MPI_Count*",
             "count"
         ]
     ],
     "MPI_Get_elements": [
         [
-            "MPI_Status*",
+            "const MPI_Status*",
             "status"
         ],
         [
@@ -2106,8 +3012,32 @@
             "datatype"
         ],
         [
-            "int*",
+            "MPI_Count*",
             "count"
+        ]
+    ],
+    "MPI_Get_elements_x": [
+        [
+            "const MPI_Status*",
+            "status"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Count*",
+            "count"
+        ]
+    ],
+    "MPI_Get_library_version": [
+        [
+            "char*",
+            "version"
+        ],
+        [
+            "int*",
+            "resultlen"
         ]
     ],
     "MPI_Get_processor_name": [
@@ -2130,53 +3060,22 @@
             "subversion"
         ]
     ],
-    "MPI_Init": [
-        [
-            "int*",
-            "argc"
-        ],
-        [
-            "char ***",
-            "argv"
-        ]
-    ],
-    "MPI_Init_thread": [
-        [
-            "int*",
-            "argc"
-        ],
-        [
-            "char***",
-            "argv"
-        ],
-		[
-			"int",
-			"req"
-		],
-		[
-			"int*",
-			"provided"
-		]
-    ],
-
     "MPI_Graph_create": [
         [
             "MPI_Comm",
-            "comm"
+            "comm_old"
         ],
         [
             "int",
             "nnodes"
         ],
         [
-            "int[]",
-            "index",
-			"nnodes"
+            "const int[]",
+            "index"
         ],
         [
-            "int[]",
-            "edges",
-			"*"
+            "const int[]",
+            "edges"
         ],
         [
             "int",
@@ -2202,13 +3101,11 @@
         ],
         [
             "int[]",
-            "index",
-			"maxindex"
+            "index"
         ],
         [
             "int[]",
-            "edges",
-			"maxedges"
+            "edges"
         ]
     ],
     "MPI_Graph_map": [
@@ -2221,14 +3118,12 @@
             "nnodes"
         ],
         [
-            "int[]",
-            "index",
-			"nnodes"
+            "const int[]",
+            "index"
         ],
         [
-            "int[]",
-            "edges",
-			"*"
+            "const int[]",
+            "edges"
         ],
         [
             "int*",
@@ -2250,8 +3145,7 @@
         ],
         [
             "int[]",
-            "neighbors",
-			"maxneighbors"
+            "neighbors"
         ]
     ],
     "MPI_Graph_neighbors_count": [
@@ -2348,9 +3242,8 @@
             "n"
         ],
         [
-            "int[]",
-            "ranks",
-			"n"
+            "const int[]",
+            "ranks"
         ],
         [
             "MPI_Group*",
@@ -2363,6 +3256,20 @@
             "group"
         ]
     ],
+    "MPI_Group_from_session_pset": [
+        [
+            "MPI_Session",
+            "session"
+        ],
+        [
+            "const char*",
+            "pset_name"
+        ],
+        [
+            "MPI_Group*",
+            "newgroup"
+        ]
+    ],
     "MPI_Group_incl": [
         [
             "MPI_Group",
@@ -2373,9 +3280,8 @@
             "n"
         ],
         [
-            "int[]",
-            "ranks",
-			"n"
+            "const int[]",
+            "ranks"
         ],
         [
             "MPI_Group*",
@@ -2407,8 +3313,7 @@
         ],
         [
             "int[][3]",
-            "ranges",
-			"n"
+            "ranges"
         ],
         [
             "MPI_Group*",
@@ -2426,8 +3331,7 @@
         ],
         [
             "int[][3]",
-            "ranges",
-			"n"
+            "ranges"
         ],
         [
             "MPI_Group*",
@@ -2464,9 +3368,8 @@
             "n"
         ],
         [
-            "int[]",
-            "ranks1",
-			"n"
+            "const int[]",
+            "ranks1"
         ],
         [
             "MPI_Group",
@@ -2474,8 +3377,7 @@
         ],
         [
             "int[]",
-            "ranks2",
-			"n"
+            "ranks2"
         ]
     ],
     "MPI_Group_union": [
@@ -2492,13 +3394,269 @@
             "newgroup"
         ]
     ],
-    "MPI_Ibsend": [
+    "MPI_Iallgather": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
         [
             "void*",
-            "buf"
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "recvcount"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Iallgatherv": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "displs"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Iallreduce": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Op",
+            "op"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Ialltoall": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "recvcount"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Ialltoallv": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "sendcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "sdispls"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "rdispls"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Ialltoallw": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "sendcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "sdispls"
+        ],
+        [
+            "const MPI_Datatype[]",
+            "sendtypes"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "rdispls"
+        ],
+        [
+            "const MPI_Datatype[]",
+            "recvtypes"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Ibarrier": [
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Ibcast": [
+        [
+            "void*",
+            "buffer"
+        ],
+        [
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
         ],
         [
             "int",
+            "root"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Ibsend": [
+        [
+            "const void*",
+            "buf"
+        ],
+        [
+            "MPI_Count",
             "count"
         ],
         [
@@ -2522,7 +3680,369 @@
             "request"
         ]
     ],
+    "MPI_Iexscan": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Op",
+            "op"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Igather": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "recvcount"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "int",
+            "root"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Igatherv": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "displs"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "int",
+            "root"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Improbe": [
+        [
+            "int",
+            "source"
+        ],
+        [
+            "int",
+            "tag"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "int*",
+            "flag"
+        ],
+        [
+            "MPI_Message*",
+            "message"
+        ],
+        [
+            "MPI_Status*",
+            "status"
+        ]
+    ],
+    "MPI_Imrecv": [
+        [
+            "void*",
+            "buf"
+        ],
+        [
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Message*",
+            "message"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Ineighbor_allgather": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "recvcount"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Ineighbor_allgatherv": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "displs"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Ineighbor_alltoall": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "recvcount"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Ineighbor_alltoallv": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "sendcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "sdispls"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "rdispls"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Ineighbor_alltoallw": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "sendcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "sdispls"
+        ],
+        [
+            "const MPI_Datatype[]",
+            "sendtypes"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "rdispls"
+        ],
+        [
+            "const MPI_Datatype[]",
+            "recvtypes"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
     "MPI_Info_create": [
+        [
+            "MPI_Info*",
+            "info"
+        ]
+    ],
+    "MPI_Info_create_env": [
+        [
+            "int",
+            "argc"
+        ],
+        [
+            "char[]",
+            "argv"
+        ],
         [
             "MPI_Info*",
             "info"
@@ -2534,7 +4054,7 @@
             "info"
         ],
         [
-            "char*",
+            "const char*",
             "key"
         ]
     ],
@@ -2560,7 +4080,7 @@
             "info"
         ],
         [
-            "char*",
+            "const char*",
             "key"
         ],
         [
@@ -2600,13 +4120,35 @@
             "key"
         ]
     ],
+    "MPI_Info_get_string": [
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "const char*",
+            "key"
+        ],
+        [
+            "int*",
+            "buflen"
+        ],
+        [
+            "char*",
+            "value"
+        ],
+        [
+            "int*",
+            "flag"
+        ]
+    ],
     "MPI_Info_get_valuelen": [
         [
             "MPI_Info",
             "info"
         ],
         [
-            "char*",
+            "const char*",
             "key"
         ],
         [
@@ -2624,15 +4166,43 @@
             "info"
         ],
         [
-            "char*",
+            "const char*",
             "key"
         ],
         [
-            "char*",
+            "const char*",
             "value"
         ]
     ],
-	"MPI_Initialized": [
+    "MPI_Init": [
+        [
+            "int*",
+            "argc"
+        ],
+        [
+            "char***",
+            "argv"
+        ]
+    ],
+    "MPI_Init_thread": [
+        [
+            "int*",
+            "argc"
+        ],
+        [
+            "char***",
+            "argv"
+        ],
+        [
+            "int",
+            "required"
+        ],
+        [
+            "int*",
+            "provided"
+        ]
+    ],
+    "MPI_Initialized": [
         [
             "int*",
             "flag"
@@ -2649,7 +4219,7 @@
         ],
         [
             "MPI_Comm",
-            "bridge_comm"
+            "peer_comm"
         ],
         [
             "int",
@@ -2658,6 +4228,40 @@
         [
             "int",
             "tag"
+        ],
+        [
+            "MPI_Comm*",
+            "newintercomm"
+        ]
+    ],
+    "MPI_Intercomm_create_from_groups": [
+        [
+            "MPI_Group",
+            "local_group"
+        ],
+        [
+            "int",
+            "local_leader"
+        ],
+        [
+            "MPI_Group",
+            "remote_group"
+        ],
+        [
+            "int",
+            "remote_leader"
+        ],
+        [
+            "const char*",
+            "stringtag"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Errhandler",
+            "errhandler"
         ],
         [
             "MPI_Comm*",
@@ -2675,7 +4279,7 @@
         ],
         [
             "MPI_Comm*",
-            "newintercomm"
+            "newintracomm"
         ]
     ],
     "MPI_Iprobe": [
@@ -2706,7 +4310,7 @@
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -2730,13 +4334,107 @@
             "request"
         ]
     ],
-    "MPI_Irsend": [
+    "MPI_Ireduce": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
         [
             "void*",
-            "buf"
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Op",
+            "op"
         ],
         [
             "int",
+            "root"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Ireduce_scatter": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Op",
+            "op"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Ireduce_scatter_block": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "recvcount"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Op",
+            "op"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Irsend": [
+        [
+            "const void*",
+            "buf"
+        ],
+        [
+            "MPI_Count",
             "count"
         ],
         [
@@ -2766,13 +4464,123 @@
             "flag"
         ]
     ],
-    "MPI_Isend": [
+    "MPI_Iscan": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
         [
             "void*",
-            "buf"
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Op",
+            "op"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Iscatter": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "recvcount"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
         ],
         [
             "int",
+            "root"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Iscatterv": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "sendcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "displs"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "recvcount"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "int",
+            "root"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Isend": [
+        [
+            "const void*",
+            "buf"
+        ],
+        [
+            "MPI_Count",
             "count"
         ],
         [
@@ -2796,13 +4604,101 @@
             "request"
         ]
     ],
-    "MPI_Issend": [
+    "MPI_Isendrecv": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "int",
+            "dest"
+        ],
+        [
+            "int",
+            "sendtag"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "recvcount"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "int",
+            "source"
+        ],
+        [
+            "int",
+            "recvtag"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Isendrecv_replace": [
         [
             "void*",
             "buf"
         ],
         [
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
             "int",
+            "dest"
+        ],
+        [
+            "int",
+            "sendtag"
+        ],
+        [
+            "int",
+            "source"
+        ],
+        [
+            "int",
+            "recvtag"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Issend": [
+        [
+            "const void*",
+            "buf"
+        ],
+        [
+            "MPI_Count",
             "count"
         ],
         [
@@ -2852,7 +4748,7 @@
     ],
     "MPI_Lookup_name": [
         [
-            "char*",
+            "const char*",
             "service_name"
         ],
         [
@@ -2864,10 +4760,444 @@
             "port_name"
         ]
     ],
+    "MPI_Mprobe": [
+        [
+            "int",
+            "source"
+        ],
+        [
+            "int",
+            "tag"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Message*",
+            "message"
+        ],
+        [
+            "MPI_Status*",
+            "status"
+        ]
+    ],
+    "MPI_Mrecv": [
+        [
+            "void*",
+            "buf"
+        ],
+        [
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Message*",
+            "message"
+        ],
+        [
+            "MPI_Status*",
+            "status"
+        ]
+    ],
+    "MPI_Neighbor_allgather": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "recvcount"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ]
+    ],
+    "MPI_Neighbor_allgather_init": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "recvcount"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Neighbor_allgatherv": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "displs"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ]
+    ],
+    "MPI_Neighbor_allgatherv_init": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "displs"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Neighbor_alltoall": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "recvcount"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ]
+    ],
+    "MPI_Neighbor_alltoall_init": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
+            "sendcount"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "recvcount"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Neighbor_alltoallv": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "sendcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "sdispls"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "rdispls"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ]
+    ],
+    "MPI_Neighbor_alltoallv_init": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "sendcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "sdispls"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "rdispls"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Neighbor_alltoallw": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "sendcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "sdispls"
+        ],
+        [
+            "const MPI_Datatype[]",
+            "sendtypes"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "rdispls"
+        ],
+        [
+            "const MPI_Datatype[]",
+            "recvtypes"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ]
+    ],
+    "MPI_Neighbor_alltoallw_init": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "sendcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "sdispls"
+        ],
+        [
+            "const MPI_Datatype[]",
+            "sendtypes"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "rdispls"
+        ],
+        [
+            "const MPI_Datatype[]",
+            "recvtypes"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Op_commutative": [
+        [
+            "MPI_Op",
+            "op"
+        ],
+        [
+            "int*",
+            "commute"
+        ]
+    ],
     "MPI_Op_create": [
         [
             "MPI_User_function*",
-            "function"
+            "user_fn"
         ],
         [
             "int",
@@ -2896,11 +5226,11 @@
     ],
     "MPI_Pack": [
         [
-            "void*",
+            "const void*",
             "inbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "incount"
         ],
         [
@@ -2912,11 +5242,11 @@
             "outbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "outsize"
         ],
         [
-            "int*",
+            "MPI_Count*",
             "position"
         ],
         [
@@ -2926,15 +5256,15 @@
     ],
     "MPI_Pack_external": [
         [
-            "char*",
+            "const char[]",
             "datarep"
         ],
         [
-            "void*",
+            "const void*",
             "inbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "incount"
         ],
         [
@@ -2946,21 +5276,21 @@
             "outbuf"
         ],
         [
-            "MPI_Aint",
+            "MPI_Count",
             "outsize"
         ],
         [
-            "MPI_Aint*",
+            "MPI_Count*",
             "position"
         ]
     ],
     "MPI_Pack_external_size": [
         [
-            "char*",
+            "const char[]",
             "datarep"
         ],
         [
-            "int",
+            "MPI_Count",
             "incount"
         ],
         [
@@ -2968,13 +5298,13 @@
             "datatype"
         ],
         [
-            "MPI_Aint*",
+            "MPI_Count*",
             "size"
         ]
     ],
     "MPI_Pack_size": [
         [
-            "int",
+            "MPI_Count",
             "incount"
         ],
         [
@@ -2986,8 +5316,108 @@
             "comm"
         ],
         [
-            "int*",
+            "MPI_Count*",
             "size"
+        ]
+    ],
+    "MPI_Parrived": [
+        [
+            "MPI_Request",
+            "request"
+        ],
+        [
+            "int",
+            "partition"
+        ],
+        [
+            "int*",
+            "flag"
+        ]
+    ],
+    "MPI_Pcontrol": [
+        [
+            "const int",
+            "level"
+        ],
+        [
+            "...",
+            ""
+        ]
+    ],
+    "MPI_Pready": [
+        [
+            "int",
+            "partition"
+        ],
+        [
+            "MPI_Request",
+            "request"
+        ]
+    ],
+    "MPI_Pready_list": [
+        [
+            "int",
+            "length"
+        ],
+        [
+            "const int[]",
+            "array_of_partitions"
+        ],
+        [
+            "MPI_Request",
+            "request"
+        ]
+    ],
+    "MPI_Pready_range": [
+        [
+            "int",
+            "partition_low"
+        ],
+        [
+            "int",
+            "partition_high"
+        ],
+        [
+            "MPI_Request",
+            "request"
+        ]
+    ],
+    "MPI_Precv_init": [
+        [
+            "void*",
+            "buf"
+        ],
+        [
+            "int",
+            "partitions"
+        ],
+        [
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "int",
+            "source"
+        ],
+        [
+            "int",
+            "tag"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
         ]
     ],
     "MPI_Probe": [
@@ -3008,9 +5438,47 @@
             "status"
         ]
     ],
+    "MPI_Psend_init": [
+        [
+            "const void*",
+            "buf"
+        ],
+        [
+            "int",
+            "partitions"
+        ],
+        [
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "int",
+            "dest"
+        ],
+        [
+            "int",
+            "tag"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
     "MPI_Publish_name": [
         [
-            "char*",
+            "const char*",
             "service_name"
         ],
         [
@@ -3018,17 +5486,17 @@
             "info"
         ],
         [
-            "char*",
+            "const char*",
             "port_name"
         ]
     ],
     "MPI_Put": [
         [
-            "void*",
+            "const void*",
             "origin_addr"
         ],
         [
-            "int",
+            "MPI_Count",
             "origin_count"
         ],
         [
@@ -3044,7 +5512,7 @@
             "target_disp"
         ],
         [
-            "int",
+            "MPI_Count",
             "target_count"
         ],
         [
@@ -3062,13 +5530,55 @@
             "provided"
         ]
     ],
+    "MPI_Raccumulate": [
+        [
+            "const void*",
+            "origin_addr"
+        ],
+        [
+            "MPI_Count",
+            "origin_count"
+        ],
+        [
+            "MPI_Datatype",
+            "origin_datatype"
+        ],
+        [
+            "int",
+            "target_rank"
+        ],
+        [
+            "MPI_Aint",
+            "target_disp"
+        ],
+        [
+            "MPI_Count",
+            "target_count"
+        ],
+        [
+            "MPI_Datatype",
+            "target_datatype"
+        ],
+        [
+            "MPI_Op",
+            "op"
+        ],
+        [
+            "MPI_Win",
+            "win"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
     "MPI_Recv": [
         [
             "void*",
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -3098,7 +5608,7 @@
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -3124,7 +5634,7 @@
     ],
     "MPI_Reduce": [
         [
-            "void*",
+            "const void*",
             "sendbuf"
         ],
         [
@@ -3132,7 +5642,7 @@
             "recvbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -3152,9 +5662,47 @@
             "comm"
         ]
     ],
-    "MPI_Reduce_local": [
+    "MPI_Reduce_init": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
         [
             "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Op",
+            "op"
+        ],
+        [
+            "int",
+            "root"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Reduce_local": [
+        [
+            "const void*",
             "inbuf"
         ],
         [
@@ -3162,7 +5710,7 @@
             "inoutbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -3176,7 +5724,7 @@
     ],
     "MPI_Reduce_scatter": [
         [
-            "void*",
+            "const void*",
             "sendbuf"
         ],
         [
@@ -3184,9 +5732,8 @@
             "recvbuf"
         ],
         [
-            "int[]",
-            "recvcounts",
-			"*"
+            "const MPI_Count[]",
+            "recvcounts"
         ],
         [
             "MPI_Datatype",
@@ -3201,9 +5748,103 @@
             "comm"
         ]
     ],
+    "MPI_Reduce_scatter_block": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "recvcount"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Op",
+            "op"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ]
+    ],
+    "MPI_Reduce_scatter_block_init": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "recvcount"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Op",
+            "op"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Reduce_scatter_init": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "recvcounts"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Op",
+            "op"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
     "MPI_Register_datarep": [
         [
-            "char*",
+            "const char*",
             "datarep"
         ],
         [
@@ -3243,13 +5884,143 @@
             "status"
         ]
     ],
-    "MPI_Rsend": [
+    "MPI_Rget": [
         [
             "void*",
-            "ibuf"
+            "origin_addr"
+        ],
+        [
+            "MPI_Count",
+            "origin_count"
+        ],
+        [
+            "MPI_Datatype",
+            "origin_datatype"
         ],
         [
             "int",
+            "target_rank"
+        ],
+        [
+            "MPI_Aint",
+            "target_disp"
+        ],
+        [
+            "MPI_Count",
+            "target_count"
+        ],
+        [
+            "MPI_Datatype",
+            "target_datatype"
+        ],
+        [
+            "MPI_Win",
+            "win"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Rget_accumulate": [
+        [
+            "const void*",
+            "origin_addr"
+        ],
+        [
+            "MPI_Count",
+            "origin_count"
+        ],
+        [
+            "MPI_Datatype",
+            "origin_datatype"
+        ],
+        [
+            "void*",
+            "result_addr"
+        ],
+        [
+            "MPI_Count",
+            "result_count"
+        ],
+        [
+            "MPI_Datatype",
+            "result_datatype"
+        ],
+        [
+            "int",
+            "target_rank"
+        ],
+        [
+            "MPI_Aint",
+            "target_disp"
+        ],
+        [
+            "MPI_Count",
+            "target_count"
+        ],
+        [
+            "MPI_Datatype",
+            "target_datatype"
+        ],
+        [
+            "MPI_Op",
+            "op"
+        ],
+        [
+            "MPI_Win",
+            "win"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Rput": [
+        [
+            "const void*",
+            "origin_addr"
+        ],
+        [
+            "MPI_Count",
+            "origin_count"
+        ],
+        [
+            "MPI_Datatype",
+            "origin_datatype"
+        ],
+        [
+            "int",
+            "target_rank"
+        ],
+        [
+            "MPI_Aint",
+            "target_disp"
+        ],
+        [
+            "MPI_Count",
+            "target_count"
+        ],
+        [
+            "MPI_Datatype",
+            "target_datatype"
+        ],
+        [
+            "MPI_Win",
+            "win"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Rsend": [
+        [
+            "const void*",
+            "buf"
+        ],
+        [
+            "MPI_Count",
             "count"
         ],
         [
@@ -3271,11 +6042,11 @@
     ],
     "MPI_Rsend_init": [
         [
-            "void*",
+            "const void*",
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -3301,7 +6072,7 @@
     ],
     "MPI_Scan": [
         [
-            "void*",
+            "const void*",
             "sendbuf"
         ],
         [
@@ -3309,7 +6080,7 @@
             "recvbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -3325,13 +6096,47 @@
             "comm"
         ]
     ],
-    "MPI_Scatter": [
+    "MPI_Scan_init": [
         [
-            "void*",
+            "const void*",
             "sendbuf"
         ],
         [
-            "int",
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Op",
+            "op"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Scatter": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "MPI_Count",
             "sendcount"
         ],
         [
@@ -3343,7 +6148,7 @@
             "recvbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "recvcount"
         ],
         [
@@ -3359,20 +6164,14 @@
             "comm"
         ]
     ],
-    "MPI_Scatterv": [
+    "MPI_Scatter_init": [
         [
-            "void*",
+            "const void*",
             "sendbuf"
         ],
         [
-            "int[]",
-            "sendcounts",
-			"*"
-        ],
-        [
-            "int[]",
-            "displs",
-			"*"
+            "MPI_Count",
+            "sendcount"
         ],
         [
             "MPI_Datatype",
@@ -3383,7 +6182,53 @@
             "recvbuf"
         ],
         [
+            "MPI_Count",
+            "recvcount"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
+        ],
+        [
             "int",
+            "root"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Scatterv": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "sendcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "displs"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
+        [
+            "void*",
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
             "recvcount"
         ],
         [
@@ -3399,13 +6244,59 @@
             "comm"
         ]
     ],
-    "MPI_Send": [
+    "MPI_Scatterv_init": [
+        [
+            "const void*",
+            "sendbuf"
+        ],
+        [
+            "const MPI_Count[]",
+            "sendcounts"
+        ],
+        [
+            "const MPI_Aint[]",
+            "displs"
+        ],
+        [
+            "MPI_Datatype",
+            "sendtype"
+        ],
         [
             "void*",
-            "buf"
+            "recvbuf"
+        ],
+        [
+            "MPI_Count",
+            "recvcount"
+        ],
+        [
+            "MPI_Datatype",
+            "recvtype"
         ],
         [
             "int",
+            "root"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Request*",
+            "request"
+        ]
+    ],
+    "MPI_Send": [
+        [
+            "const void*",
+            "buf"
+        ],
+        [
+            "MPI_Count",
             "count"
         ],
         [
@@ -3427,11 +6318,11 @@
     ],
     "MPI_Send_init": [
         [
-            "void*",
+            "const void*",
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -3457,11 +6348,11 @@
     ],
     "MPI_Sendrecv": [
         [
-            "void*",
+            "const void*",
             "sendbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "sendcount"
         ],
         [
@@ -3481,7 +6372,7 @@
             "recvbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "recvcount"
         ],
         [
@@ -3511,7 +6402,7 @@
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -3543,13 +6434,133 @@
             "status"
         ]
     ],
-    "MPI_Ssend": [
+    "MPI_Session_call_errhandler": [
         [
-            "void*",
-            "buf"
+            "MPI_Session",
+            "session"
         ],
         [
             "int",
+            "errorcode"
+        ]
+    ],
+    "MPI_Session_create_errhandler": [
+        [
+            "MPI_Session_errhandler_function*",
+            "session_errhandler_fn"
+        ],
+        [
+            "MPI_Errhandler*",
+            "errhandler"
+        ]
+    ],
+    "MPI_Session_finalize": [
+        [
+            "MPI_Session*",
+            "session"
+        ]
+    ],
+    "MPI_Session_get_errhandler": [
+        [
+            "MPI_Session",
+            "session"
+        ],
+        [
+            "MPI_Errhandler*",
+            "errhandler"
+        ]
+    ],
+    "MPI_Session_get_info": [
+        [
+            "MPI_Session",
+            "session"
+        ],
+        [
+            "MPI_Info*",
+            "info_used"
+        ]
+    ],
+    "MPI_Session_get_nth_pset": [
+        [
+            "MPI_Session",
+            "session"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "int",
+            "n"
+        ],
+        [
+            "int*",
+            "pset_len"
+        ],
+        [
+            "char*",
+            "pset_name"
+        ]
+    ],
+    "MPI_Session_get_num_psets": [
+        [
+            "MPI_Session",
+            "session"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "int*",
+            "npset_names"
+        ]
+    ],
+    "MPI_Session_get_pset_info": [
+        [
+            "MPI_Session",
+            "session"
+        ],
+        [
+            "const char*",
+            "pset_name"
+        ],
+        [
+            "MPI_Info*",
+            "info"
+        ]
+    ],
+    "MPI_Session_init": [
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Errhandler",
+            "errhandler"
+        ],
+        [
+            "MPI_Session*",
+            "session"
+        ]
+    ],
+    "MPI_Session_set_errhandler": [
+        [
+            "MPI_Session",
+            "session"
+        ],
+        [
+            "MPI_Errhandler",
+            "errhandler"
+        ]
+    ],
+    "MPI_Ssend": [
+        [
+            "const void*",
+            "buf"
+        ],
+        [
+            "MPI_Count",
             "count"
         ],
         [
@@ -3571,11 +6582,11 @@
     ],
     "MPI_Ssend_init": [
         [
-            "void*",
+            "const void*",
             "buf"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -3612,8 +6623,7 @@
         ],
         [
             "MPI_Request[]",
-            "array_of_requests",
-			"count"
+            "array_of_requests"
         ]
     ],
     "MPI_Status_set_cancelled": [
@@ -3636,8 +6646,763 @@
             "datatype"
         ],
         [
-            "int",
+            "MPI_Count",
             "count"
+        ]
+    ],
+    "MPI_Status_set_elements_x": [
+        [
+            "MPI_Status*",
+            "status"
+        ],
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Count",
+            "count"
+        ]
+    ],
+    "MPI_T_category_changed": [
+        [
+            "int*",
+            "update_number"
+        ]
+    ],
+    "MPI_T_category_get_categories": [
+        [
+            "int",
+            "cat_index"
+        ],
+        [
+            "int",
+            "len"
+        ],
+        [
+            "int[]",
+            "indices"
+        ]
+    ],
+    "MPI_T_category_get_cvars": [
+        [
+            "int",
+            "cat_index"
+        ],
+        [
+            "int",
+            "len"
+        ],
+        [
+            "int[]",
+            "indices"
+        ]
+    ],
+    "MPI_T_category_get_events": [
+        [
+            "int",
+            "cat_index"
+        ],
+        [
+            "int",
+            "len"
+        ],
+        [
+            "int[]",
+            "indices"
+        ]
+    ],
+    "MPI_T_category_get_index": [
+        [
+            "const char*",
+            "name"
+        ],
+        [
+            "int*",
+            "cat_index"
+        ]
+    ],
+    "MPI_T_category_get_info": [
+        [
+            "int",
+            "cat_index"
+        ],
+        [
+            "char*",
+            "name"
+        ],
+        [
+            "int*",
+            "name_len"
+        ],
+        [
+            "char*",
+            "desc"
+        ],
+        [
+            "int*",
+            "desc_len"
+        ],
+        [
+            "int*",
+            "num_cvars"
+        ],
+        [
+            "int*",
+            "num_pvars"
+        ],
+        [
+            "int*",
+            "num_categories"
+        ]
+    ],
+    "MPI_T_category_get_num": [
+        [
+            "int*",
+            "num_cat"
+        ]
+    ],
+    "MPI_T_category_get_num_events": [
+        [
+            "int",
+            "cat_index"
+        ],
+        [
+            "int*",
+            "num_events"
+        ]
+    ],
+    "MPI_T_category_get_pvars": [
+        [
+            "int",
+            "cat_index"
+        ],
+        [
+            "int",
+            "len"
+        ],
+        [
+            "int[]",
+            "indices"
+        ]
+    ],
+    "MPI_T_cvar_get_index": [
+        [
+            "const char*",
+            "name"
+        ],
+        [
+            "int*",
+            "cvar_index"
+        ]
+    ],
+    "MPI_T_cvar_get_info": [
+        [
+            "int",
+            "cvar_index"
+        ],
+        [
+            "char*",
+            "name"
+        ],
+        [
+            "int*",
+            "name_len"
+        ],
+        [
+            "int*",
+            "verbosity"
+        ],
+        [
+            "MPI_Datatype*",
+            "datatype"
+        ],
+        [
+            "MPI_T_enum*",
+            "enumtype"
+        ],
+        [
+            "char*",
+            "desc"
+        ],
+        [
+            "int*",
+            "desc_len"
+        ],
+        [
+            "int*",
+            "bind"
+        ],
+        [
+            "int*",
+            "scope"
+        ]
+    ],
+    "MPI_T_cvar_get_num": [
+        [
+            "int*",
+            "num_cvar"
+        ]
+    ],
+    "MPI_T_cvar_handle_alloc": [
+        [
+            "int",
+            "cvar_index"
+        ],
+        [
+            "void*",
+            "obj_handle"
+        ],
+        [
+            "MPI_T_cvar_handle*",
+            "handle"
+        ],
+        [
+            "int*",
+            "count"
+        ]
+    ],
+    "MPI_T_cvar_handle_free": [
+        [
+            "MPI_T_cvar_handle*",
+            "handle"
+        ]
+    ],
+    "MPI_T_cvar_read": [
+        [
+            "MPI_T_cvar_handle",
+            "handle"
+        ],
+        [
+            "void*",
+            "buf"
+        ]
+    ],
+    "MPI_T_cvar_write": [
+        [
+            "MPI_T_cvar_handle",
+            "handle"
+        ],
+        [
+            "const void*",
+            "buf"
+        ]
+    ],
+    "MPI_T_enum_get_info": [
+        [
+            "MPI_T_enum",
+            "enumtype"
+        ],
+        [
+            "int*",
+            "num"
+        ],
+        [
+            "char*",
+            "name"
+        ],
+        [
+            "int*",
+            "name_len"
+        ]
+    ],
+    "MPI_T_enum_get_item": [
+        [
+            "MPI_T_enum",
+            "enumtype"
+        ],
+        [
+            "int",
+            "index"
+        ],
+        [
+            "int*",
+            "value"
+        ],
+        [
+            "char*",
+            "name"
+        ],
+        [
+            "int*",
+            "name_len"
+        ]
+    ],
+    "MPI_T_event_callback_get_info": [
+        [
+            "MPI_T_event_registration",
+            "event_registration"
+        ],
+        [
+            "MPI_T_cb_safety",
+            "cb_safety"
+        ],
+        [
+            "MPI_Info*",
+            "info_used"
+        ]
+    ],
+    "MPI_T_event_callback_set_info": [
+        [
+            "MPI_T_event_registration",
+            "event_registration"
+        ],
+        [
+            "MPI_T_cb_safety",
+            "cb_safety"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ]
+    ],
+    "MPI_T_event_copy": [
+        [
+            "MPI_T_event_instance",
+            "event_instance"
+        ],
+        [
+            "void*",
+            "buffer"
+        ]
+    ],
+    "MPI_T_event_get_index": [
+        [
+            "const char*",
+            "name"
+        ],
+        [
+            "int*",
+            "event_index"
+        ]
+    ],
+    "MPI_T_event_get_info": [
+        [
+            "int",
+            "event_index"
+        ],
+        [
+            "char*",
+            "name"
+        ],
+        [
+            "int*",
+            "name_len"
+        ],
+        [
+            "int*",
+            "verbosity"
+        ],
+        [
+            "MPI_Datatype[]",
+            "array_of_datatypes"
+        ],
+        [
+            "MPI_Aint[]",
+            "array_of_displacements"
+        ],
+        [
+            "int*",
+            "num_elements"
+        ],
+        [
+            "MPI_T_enum*",
+            "enumtype"
+        ],
+        [
+            "MPI_Info*",
+            "info"
+        ],
+        [
+            "char*",
+            "desc"
+        ],
+        [
+            "int*",
+            "desc_len"
+        ],
+        [
+            "int*",
+            "bind"
+        ]
+    ],
+    "MPI_T_event_get_num": [
+        [
+            "int*",
+            "num_events"
+        ]
+    ],
+    "MPI_T_event_get_source": [
+        [
+            "MPI_T_event_instance",
+            "event_instance"
+        ],
+        [
+            "int*",
+            "source_index"
+        ]
+    ],
+    "MPI_T_event_get_timestamp": [
+        [
+            "MPI_T_event_instance",
+            "event_instance"
+        ],
+        [
+            "MPI_Count*",
+            "event_timestamp"
+        ]
+    ],
+    "MPI_T_event_handle_alloc": [
+        [
+            "int",
+            "event_index"
+        ],
+        [
+            "void*",
+            "obj_handle"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_T_event_registration*",
+            "event_registration"
+        ]
+    ],
+    "MPI_T_event_handle_free": [
+        [
+            "MPI_T_event_registration",
+            "event_registration"
+        ],
+        [
+            "void*",
+            "user_data"
+        ],
+        [
+            "MPI_T_event_free_cb_function",
+            "free_cb_function"
+        ]
+    ],
+    "MPI_T_event_handle_get_info": [
+        [
+            "MPI_T_event_registration",
+            "event_registration"
+        ],
+        [
+            "MPI_Info*",
+            "info_used"
+        ]
+    ],
+    "MPI_T_event_handle_set_info": [
+        [
+            "MPI_T_event_registration",
+            "event_registration"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ]
+    ],
+    "MPI_T_event_read": [
+        [
+            "MPI_T_event_instance",
+            "event_instance"
+        ],
+        [
+            "int",
+            "element_index"
+        ],
+        [
+            "void*",
+            "buffer"
+        ]
+    ],
+    "MPI_T_event_register_callback": [
+        [
+            "MPI_T_event_registration",
+            "event_registration"
+        ],
+        [
+            "MPI_T_cb_safety",
+            "cb_safety"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "void*",
+            "user_data"
+        ],
+        [
+            "MPI_T_event_cb_function",
+            "event_cb_function"
+        ]
+    ],
+    "MPI_T_event_set_dropped_handler": [
+        [
+            "MPI_T_event_registration",
+            "event_registration"
+        ],
+        [
+            "MPI_T_event_dropped_cb_function",
+            "dropped_cb_function"
+        ]
+    ],
+    "MPI_T_finalize": [],
+    "MPI_T_init_thread": [
+        [
+            "int",
+            "required"
+        ],
+        [
+            "int*",
+            "provided"
+        ]
+    ],
+    "MPI_T_pvar_get_index": [
+        [
+            "const char*",
+            "name"
+        ],
+        [
+            "int",
+            "var_class"
+        ],
+        [
+            "int*",
+            "pvar_index"
+        ]
+    ],
+    "MPI_T_pvar_get_info": [
+        [
+            "int",
+            "pvar_index"
+        ],
+        [
+            "char*",
+            "name"
+        ],
+        [
+            "int*",
+            "name_len"
+        ],
+        [
+            "int*",
+            "verbosity"
+        ],
+        [
+            "int*",
+            "var_class"
+        ],
+        [
+            "MPI_Datatype*",
+            "datatype"
+        ],
+        [
+            "MPI_T_enum*",
+            "enumtype"
+        ],
+        [
+            "char*",
+            "desc"
+        ],
+        [
+            "int*",
+            "desc_len"
+        ],
+        [
+            "int*",
+            "bind"
+        ],
+        [
+            "int*",
+            "readonly"
+        ],
+        [
+            "int*",
+            "continuous"
+        ],
+        [
+            "int*",
+            "atomic"
+        ]
+    ],
+    "MPI_T_pvar_get_num": [
+        [
+            "int*",
+            "num_pvar"
+        ]
+    ],
+    "MPI_T_pvar_handle_alloc": [
+        [
+            "MPI_T_pvar_session",
+            "pe_session"
+        ],
+        [
+            "int",
+            "pvar_index"
+        ],
+        [
+            "void*",
+            "obj_handle"
+        ],
+        [
+            "MPI_T_pvar_handle*",
+            "handle"
+        ],
+        [
+            "int*",
+            "count"
+        ]
+    ],
+    "MPI_T_pvar_handle_free": [
+        [
+            "MPI_T_pvar_session",
+            "pe_session"
+        ],
+        [
+            "MPI_T_pvar_handle*",
+            "handle"
+        ]
+    ],
+    "MPI_T_pvar_read": [
+        [
+            "MPI_T_pvar_session",
+            "pe_session"
+        ],
+        [
+            "MPI_T_pvar_handle",
+            "handle"
+        ],
+        [
+            "void*",
+            "buf"
+        ]
+    ],
+    "MPI_T_pvar_readreset": [
+        [
+            "MPI_T_pvar_session",
+            "pe_session"
+        ],
+        [
+            "MPI_T_pvar_handle",
+            "handle"
+        ],
+        [
+            "void*",
+            "buf"
+        ]
+    ],
+    "MPI_T_pvar_reset": [
+        [
+            "MPI_T_pvar_session",
+            "pe_session"
+        ],
+        [
+            "MPI_T_pvar_handle",
+            "handle"
+        ]
+    ],
+    "MPI_T_pvar_session_create": [
+        [
+            "MPI_T_pvar_session*",
+            "pe_session"
+        ]
+    ],
+    "MPI_T_pvar_session_free": [
+        [
+            "MPI_T_pvar_session*",
+            "pe_session"
+        ]
+    ],
+    "MPI_T_pvar_start": [
+        [
+            "MPI_T_pvar_session",
+            "pe_session"
+        ],
+        [
+            "MPI_T_pvar_handle",
+            "handle"
+        ]
+    ],
+    "MPI_T_pvar_stop": [
+        [
+            "MPI_T_pvar_session",
+            "pe_session"
+        ],
+        [
+            "MPI_T_pvar_handle",
+            "handle"
+        ]
+    ],
+    "MPI_T_pvar_write": [
+        [
+            "MPI_T_pvar_session",
+            "pe_session"
+        ],
+        [
+            "MPI_T_pvar_handle",
+            "handle"
+        ],
+        [
+            "const void*",
+            "buf"
+        ]
+    ],
+    "MPI_T_source_get_info": [
+        [
+            "int",
+            "source_index"
+        ],
+        [
+            "char*",
+            "name"
+        ],
+        [
+            "int*",
+            "name_len"
+        ],
+        [
+            "char*",
+            "desc"
+        ],
+        [
+            "int*",
+            "desc_len"
+        ],
+        [
+            "MPI_T_source_order*",
+            "ordering"
+        ],
+        [
+            "MPI_Count*",
+            "ticks_per_second"
+        ],
+        [
+            "MPI_Count*",
+            "max_ticks"
+        ],
+        [
+            "MPI_Info*",
+            "info"
+        ]
+    ],
+    "MPI_T_source_get_num": [
+        [
+            "int*",
+            "num_sources"
+        ]
+    ],
+    "MPI_T_source_get_timestamp": [
+        [
+            "int",
+            "source_index"
+        ],
+        [
+            "MPI_Count*",
+            "timestamp"
         ]
     ],
     "MPI_Test": [
@@ -3656,7 +7421,7 @@
     ],
     "MPI_Test_cancelled": [
         [
-            "MPI_Status*",
+            "const MPI_Status*",
             "status"
         ],
         [
@@ -3671,8 +7436,7 @@
         ],
         [
             "MPI_Request[]",
-            "array_of_requests",
-			"count"
+            "array_of_requests"
         ],
         [
             "int*",
@@ -3680,8 +7444,7 @@
         ],
         [
             "MPI_Status[]",
-            "array_of_statuses",
-			"count"
+            "array_of_statuses"
         ]
     ],
     "MPI_Testany": [
@@ -3691,8 +7454,7 @@
         ],
         [
             "MPI_Request[]",
-            "array_of_requests",
-			"count"
+            "array_of_requests"
         ],
         [
             "int*",
@@ -3714,8 +7476,7 @@
         ],
         [
             "MPI_Request[]",
-            "array_of_requests",
-			"incount"
+            "array_of_requests"
         ],
         [
             "int*",
@@ -3723,13 +7484,11 @@
         ],
         [
             "int[]",
-            "array_of_indices",
-			"*"
+            "array_of_indices"
         ],
         [
             "MPI_Status[]",
-            "array_of_statuses",
-			"*"
+            "array_of_statuses"
         ]
     ],
     "MPI_Topo_test": [
@@ -3745,12 +7504,12 @@
     "MPI_Type_commit": [
         [
             "MPI_Datatype*",
-            "type"
+            "datatype"
         ]
     ],
     "MPI_Type_contiguous": [
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
@@ -3776,24 +7535,20 @@
             "ndims"
         ],
         [
-            "int[]",
-            "gsize_array",
-			"ndims"
+            "const MPI_Count[]",
+            "array_of_gsizes"
         ],
         [
-            "int[]",
-            "distrib_array",
-			"ndims"
+            "const int[]",
+            "array_of_distribs"
         ],
         [
-            "int[]",
-            "darg_array",
-			"ndims"
+            "const int[]",
+            "array_of_dargs"
         ],
         [
-            "int[]",
-            "psize_array",
-			"ndims"
+            "const int[]",
+            "array_of_psizes"
         ],
         [
             "int",
@@ -3808,20 +7563,78 @@
             "newtype"
         ]
     ],
-    "MPI_Type_create_hindexed": [
+    "MPI_Type_create_f90_complex": [
         [
             "int",
+            "p"
+        ],
+        [
+            "int",
+            "r"
+        ],
+        [
+            "MPI_Datatype*",
+            "newtype"
+        ]
+    ],
+    "MPI_Type_create_f90_integer": [
+        [
+            "int",
+            "r"
+        ],
+        [
+            "MPI_Datatype*",
+            "newtype"
+        ]
+    ],
+    "MPI_Type_create_f90_real": [
+        [
+            "int",
+            "p"
+        ],
+        [
+            "int",
+            "r"
+        ],
+        [
+            "MPI_Datatype*",
+            "newtype"
+        ]
+    ],
+    "MPI_Type_create_hindexed": [
+        [
+            "MPI_Count",
             "count"
         ],
         [
-            "int[]",
-            "array_of_blocklengths",
-			"count"
+            "const MPI_Count[]",
+            "array_of_blocklengths"
         ],
         [
-            "MPI_Aint[]",
-            "array_of_displacements",
-			"count"
+            "const MPI_Count[]",
+            "array_of_displacements"
+        ],
+        [
+            "MPI_Datatype",
+            "oldtype"
+        ],
+        [
+            "MPI_Datatype*",
+            "newtype"
+        ]
+    ],
+    "MPI_Type_create_hindexed_block": [
+        [
+            "MPI_Count",
+            "count"
+        ],
+        [
+            "MPI_Count",
+            "blocklength"
+        ],
+        [
+            "const MPI_Count[]",
+            "array_of_displacements"
         ],
         [
             "MPI_Datatype",
@@ -3834,15 +7647,15 @@
     ],
     "MPI_Type_create_hvector": [
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
-            "int",
+            "MPI_Count",
             "blocklength"
         ],
         [
-            "MPI_Aint",
+            "MPI_Count",
             "stride"
         ],
         [
@@ -3856,17 +7669,16 @@
     ],
     "MPI_Type_create_indexed_block": [
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
-            "int",
+            "MPI_Count",
             "blocklength"
         ],
         [
-            "int[]",
-            "array_of_displacements",
-			"count"
+            "const MPI_Count[]",
+            "array_of_displacements"
         ],
         [
             "MPI_Datatype",
@@ -3901,11 +7713,11 @@
             "oldtype"
         ],
         [
-            "MPI_Aint",
+            "MPI_Count",
             "lb"
         ],
         [
-            "MPI_Aint",
+            "MPI_Count",
             "extent"
         ],
         [
@@ -3915,23 +7727,20 @@
     ],
     "MPI_Type_create_struct": [
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
-            "int[]",
-            "array_of_block_lengths",
-			"count"
+            "const MPI_Count[]",
+            "array_of_blocklengths"
         ],
         [
-            "MPI_Aint[]",
-            "array_of_displacements",
-			"count"
+            "const MPI_Count[]",
+            "array_of_displacements"
         ],
         [
-            "MPI_Datatype[]",
-            "array_of_types",
-			"count"
+            "const MPI_Datatype[]",
+            "array_of_types"
         ],
         [
             "MPI_Datatype*",
@@ -3944,19 +7753,16 @@
             "ndims"
         ],
         [
-            "int[]",
-            "size_array",
-			"ndims"
+            "const MPI_Count[]",
+            "array_of_sizes"
         ],
         [
-            "int[]",
-            "subsize_array",
-			"ndims"
+            "const MPI_Count[]",
+            "array_of_subsizes"
         ],
         [
-            "int[]",
-            "start_array",
-			"ndims"
+            "const MPI_Count[]",
+            "array_of_starts"
         ],
         [
             "int",
@@ -3974,7 +7780,7 @@
     "MPI_Type_delete_attr": [
         [
             "MPI_Datatype",
-            "type"
+            "datatype"
         ],
         [
             "int",
@@ -3984,27 +7790,17 @@
     "MPI_Type_dup": [
         [
             "MPI_Datatype",
-            "type"
+            "oldtype"
         ],
         [
             "MPI_Datatype*",
             "newtype"
         ]
     ],
-    "MPI_Type_extent": [
-        [
-            "MPI_Datatype",
-            "type"
-        ],
-        [
-            "MPI_Aint*",
-            "extent"
-        ]
-    ],
     "MPI_Type_free": [
         [
             "MPI_Datatype*",
-            "type"
+            "datatype"
         ]
     ],
     "MPI_Type_free_keyval": [
@@ -4016,7 +7812,7 @@
     "MPI_Type_get_attr": [
         [
             "MPI_Datatype",
-            "type"
+            "datatype"
         ],
         [
             "int",
@@ -4034,51 +7830,60 @@
     "MPI_Type_get_contents": [
         [
             "MPI_Datatype",
-            "mtype"
+            "datatype"
         ],
         [
-            "int",
+            "MPI_Count",
             "max_integers"
         ],
         [
-            "int",
+            "MPI_Count",
             "max_addresses"
         ],
         [
-            "int",
+            "MPI_Count",
+            "max_large_counts"
+        ],
+        [
+            "MPI_Count",
             "max_datatypes"
         ],
         [
             "int[]",
-            "array_of_integers",
-			"max_integers"
+            "array_of_integers"
         ],
         [
             "MPI_Aint[]",
-            "array_of_addresses",
-			"max_addresses"
+            "array_of_addresses"
+        ],
+        [
+            "MPI_Count[]",
+            "array_of_large_counts"
         ],
         [
             "MPI_Datatype[]",
-            "array_of_datatypes",
-			"max_datatypes"
+            "array_of_datatypes"
         ]
     ],
     "MPI_Type_get_envelope": [
         [
             "MPI_Datatype",
-            "type"
+            "datatype"
         ],
         [
-            "int*",
+            "MPI_Count*",
             "num_integers"
         ],
         [
-            "int*",
+            "MPI_Count*",
             "num_addresses"
         ],
         [
-            "int*",
+            "MPI_Count*",
+            "num_large_counts"
+        ],
+        [
+            "MPI_Count*",
             "num_datatypes"
         ],
         [
@@ -4089,21 +7894,35 @@
     "MPI_Type_get_extent": [
         [
             "MPI_Datatype",
-            "type"
+            "datatype"
         ],
         [
-            "MPI_Aint*",
+            "MPI_Count*",
             "lb"
         ],
         [
-            "MPI_Aint*",
+            "MPI_Count*",
+            "extent"
+        ]
+    ],
+    "MPI_Type_get_extent_x": [
+        [
+            "MPI_Datatype",
+            "datatype"
+        ],
+        [
+            "MPI_Count*",
+            "lb"
+        ],
+        [
+            "MPI_Count*",
             "extent"
         ]
     ],
     "MPI_Type_get_name": [
         [
             "MPI_Datatype",
-            "type"
+            "datatype"
         ],
         [
             "char*",
@@ -4120,74 +7939,40 @@
             "datatype"
         ],
         [
-            "MPI_Aint*",
+            "MPI_Count*",
             "true_lb"
         ],
         [
-            "MPI_Aint*",
+            "MPI_Count*",
             "true_extent"
         ]
     ],
-    "MPI_Type_hindexed": [
-        [
-            "int",
-            "count"
-        ],
-        [
-            "int[]",
-            "array_of_blocklengths",
-			"count"
-        ],
-        [
-            "MPI_Aint[]",
-            "array_of_displacements",
-			"count"
-        ],
+    "MPI_Type_get_true_extent_x": [
         [
             "MPI_Datatype",
-            "oldtype"
+            "datatype"
         ],
         [
-            "MPI_Datatype*",
-            "newtype"
-        ]
-    ],
-    "MPI_Type_hvector": [
-        [
-            "int",
-            "count"
+            "MPI_Count*",
+            "true_lb"
         ],
         [
-            "int",
-            "blocklength"
-        ],
-        [
-            "MPI_Aint",
-            "stride"
-        ],
-        [
-            "MPI_Datatype",
-            "oldtype"
-        ],
-        [
-            "MPI_Datatype*",
-            "newtype"
+            "MPI_Count*",
+            "true_extent"
         ]
     ],
     "MPI_Type_indexed": [
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
-            "int[]",
-            "array_of_blocklengths",
-			"count"
+            "const MPI_Count[]",
+            "array_of_blocklengths"
         ],
         [
-            "int[]",
-            "array_of_displacements",
-			"count"
+            "const MPI_Count[]",
+            "array_of_displacements"
         ],
         [
             "MPI_Datatype",
@@ -4196,16 +7981,6 @@
         [
             "MPI_Datatype*",
             "newtype"
-        ]
-    ],
-    "MPI_Type_lb": [
-        [
-            "MPI_Datatype",
-            "type"
-        ],
-        [
-            "MPI_Aint*",
-            "lb"
         ]
     ],
     "MPI_Type_match_size": [
@@ -4219,13 +7994,13 @@
         ],
         [
             "MPI_Datatype*",
-            "type"
+            "datatype"
         ]
     ],
     "MPI_Type_set_attr": [
         [
             "MPI_Datatype",
-            "type"
+            "datatype"
         ],
         [
             "int",
@@ -4233,75 +8008,50 @@
         ],
         [
             "void*",
-            "attr_val"
+            "attribute_val"
         ]
     ],
     "MPI_Type_set_name": [
         [
             "MPI_Datatype",
-            "type"
+            "datatype"
         ],
         [
-            "char*",
+            "const char*",
             "type_name"
         ]
     ],
     "MPI_Type_size": [
         [
             "MPI_Datatype",
-            "type"
+            "datatype"
         ],
         [
-            "int*",
+            "MPI_Count*",
             "size"
         ]
     ],
-    "MPI_Type_struct": [
-        [
-            "int",
-            "count"
-        ],
-        [
-            "int[]",
-            "array_of_blocklengths",
-			"count"
-        ],
-        [
-            "MPI_Aint[]",
-            "array_of_displacements",
-			"count"
-        ],
-        [
-            "MPI_Datatype[]",
-            "array_of_types",
-			"count"
-        ],
-        [
-            "MPI_Datatype*",
-            "newtype"
-        ]
-    ],
-    "MPI_Type_ub": [
+    "MPI_Type_size_x": [
         [
             "MPI_Datatype",
-            "mtype"
+            "datatype"
         ],
         [
-            "MPI_Aint*",
-            "ub"
+            "MPI_Count*",
+            "size"
         ]
     ],
     "MPI_Type_vector": [
         [
-            "int",
+            "MPI_Count",
             "count"
         ],
         [
-            "int",
+            "MPI_Count",
             "blocklength"
         ],
         [
-            "int",
+            "MPI_Count",
             "stride"
         ],
         [
@@ -4315,15 +8065,15 @@
     ],
     "MPI_Unpack": [
         [
-            "void*",
+            "const void*",
             "inbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "insize"
         ],
         [
-            "int*",
+            "MPI_Count*",
             "position"
         ],
         [
@@ -4331,7 +8081,7 @@
             "outbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "outcount"
         ],
         [
@@ -4345,19 +8095,19 @@
     ],
     "MPI_Unpack_external": [
         [
-            "char*",
+            "const char[]",
             "datarep"
         ],
         [
-            "void*",
+            "const void*",
             "inbuf"
         ],
         [
-            "MPI_Aint",
+            "MPI_Count",
             "insize"
         ],
         [
-            "MPI_Aint*",
+            "MPI_Count*",
             "position"
         ],
         [
@@ -4365,7 +8115,7 @@
             "outbuf"
         ],
         [
-            "int",
+            "MPI_Count",
             "outcount"
         ],
         [
@@ -4375,7 +8125,7 @@
     ],
     "MPI_Unpublish_name": [
         [
-            "char*",
+            "const char*",
             "service_name"
         ],
         [
@@ -4383,7 +8133,7 @@
             "info"
         ],
         [
-            "char*",
+            "const char*",
             "port_name"
         ]
     ],
@@ -4404,13 +8154,11 @@
         ],
         [
             "MPI_Request[]",
-            "array_of_requests",
-			"count"
+            "array_of_requests"
         ],
         [
             "MPI_Status[]",
-            "array_of_statuses",
-			"count"
+            "array_of_statuses"
         ]
     ],
     "MPI_Waitany": [
@@ -4420,8 +8168,7 @@
         ],
         [
             "MPI_Request[]",
-            "array_of_requests",
-			"count"
+            "array_of_requests"
         ],
         [
             "int*",
@@ -4439,8 +8186,7 @@
         ],
         [
             "MPI_Request[]",
-            "array_of_requests",
-			"incount"
+            "array_of_requests"
         ],
         [
             "int*",
@@ -4448,13 +8194,77 @@
         ],
         [
             "int[]",
-            "array_of_indices",
-			"*"
+            "array_of_indices"
         ],
         [
             "MPI_Status[]",
-            "array_of_statuses",
-			"*"
+            "array_of_statuses"
+        ]
+    ],
+    "MPI_Win_allocate": [
+        [
+            "MPI_Aint",
+            "size"
+        ],
+        [
+            "MPI_Aint",
+            "disp_unit"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "void*",
+            "baseptr"
+        ],
+        [
+            "MPI_Win*",
+            "win"
+        ]
+    ],
+    "MPI_Win_allocate_shared": [
+        [
+            "MPI_Aint",
+            "size"
+        ],
+        [
+            "MPI_Aint",
+            "disp_unit"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "void*",
+            "baseptr"
+        ],
+        [
+            "MPI_Win*",
+            "win"
+        ]
+    ],
+    "MPI_Win_attach": [
+        [
+            "MPI_Win",
+            "win"
+        ],
+        [
+            "void*",
+            "base"
+        ],
+        [
+            "MPI_Aint",
+            "size"
         ]
     ],
     "MPI_Win_call_errhandler": [
@@ -4483,9 +8293,23 @@
             "size"
         ],
         [
-            "int",
+            "MPI_Aint",
             "disp_unit"
         ],
+        [
+            "MPI_Info",
+            "info"
+        ],
+        [
+            "MPI_Comm",
+            "comm"
+        ],
+        [
+            "MPI_Win*",
+            "win"
+        ]
+    ],
+    "MPI_Win_create_dynamic": [
         [
             "MPI_Info",
             "info"
@@ -4502,7 +8326,7 @@
     "MPI_Win_create_errhandler": [
         [
             "MPI_Win_errhandler_function*",
-            "function"
+            "win_errhandler_fn"
         ],
         [
             "MPI_Errhandler*",
@@ -4537,11 +8361,53 @@
             "win_keyval"
         ]
     ],
+    "MPI_Win_detach": [
+        [
+            "MPI_Win",
+            "win"
+        ],
+        [
+            "const void*",
+            "base"
+        ]
+    ],
     "MPI_Win_fence": [
         [
             "int",
             "assert"
         ],
+        [
+            "MPI_Win",
+            "win"
+        ]
+    ],
+    "MPI_Win_flush": [
+        [
+            "int",
+            "rank"
+        ],
+        [
+            "MPI_Win",
+            "win"
+        ]
+    ],
+    "MPI_Win_flush_all": [
+        [
+            "MPI_Win",
+            "win"
+        ]
+    ],
+    "MPI_Win_flush_local": [
+        [
+            "int",
+            "rank"
+        ],
+        [
+            "MPI_Win",
+            "win"
+        ]
+    ],
+    "MPI_Win_flush_local_all": [
         [
             "MPI_Win",
             "win"
@@ -4597,6 +8463,16 @@
             "group"
         ]
     ],
+    "MPI_Win_get_info": [
+        [
+            "MPI_Win",
+            "win"
+        ],
+        [
+            "MPI_Info*",
+            "info_used"
+        ]
+    ],
     "MPI_Win_get_name": [
         [
             "MPI_Win",
@@ -4620,6 +8496,16 @@
             "int",
             "rank"
         ],
+        [
+            "int",
+            "assert"
+        ],
+        [
+            "MPI_Win",
+            "win"
+        ]
+    ],
+    "MPI_Win_lock_all": [
         [
             "int",
             "assert"
@@ -4667,14 +8553,46 @@
             "errhandler"
         ]
     ],
+    "MPI_Win_set_info": [
+        [
+            "MPI_Win",
+            "win"
+        ],
+        [
+            "MPI_Info",
+            "info"
+        ]
+    ],
     "MPI_Win_set_name": [
         [
             "MPI_Win",
             "win"
         ],
         [
-            "char*",
+            "const char*",
             "win_name"
+        ]
+    ],
+    "MPI_Win_shared_query": [
+        [
+            "MPI_Win",
+            "win"
+        ],
+        [
+            "int",
+            "rank"
+        ],
+        [
+            "MPI_Aint*",
+            "size"
+        ],
+        [
+            "MPI_Aint*",
+            "disp_unit"
+        ],
+        [
+            "void*",
+            "baseptr"
         ]
     ],
     "MPI_Win_start": [
@@ -4686,6 +8604,12 @@
             "int",
             "assert"
         ],
+        [
+            "MPI_Win",
+            "win"
+        ]
+    ],
+    "MPI_Win_sync": [
         [
             "MPI_Win",
             "win"
@@ -4711,102 +8635,18 @@
             "win"
         ]
     ],
+    "MPI_Win_unlock_all": [
+        [
+            "MPI_Win",
+            "win"
+        ]
+    ],
     "MPI_Win_wait": [
         [
             "MPI_Win",
             "win"
         ]
     ],
-	"MPI_Mprobe": [
-		[
-			"int",
-			"source"
-		],
-		[
-			"int",
-			"tag"
-		],
-		[
-			"MPI_Comm",
-			"comm"
-		],
-		[
-			"MPI_Message*",
-			"message"
-		],
-		[
-			"MPI_Status*",
-			"status"
-		]
-	],
-	"MPI_Improbe": [
-		[
-			"int",
-			"source"
-		],
-		[
-			"int",
-			"tag"
-		],
-		[
-			"MPI_Comm",
-			"comm"
-		],
-		[
-			"int*",
-			"flag"
-		],
-		[
-			"MPI_Message*",
-			"message"
-		],
-		[
-			"MPI_Status*",
-			"status"
-		]
-	],
-	"MPI_Mrecv": [
-		[
-			"void*",
-			"buf"
-		],
-		[
-			"int",
-			"count"
-		],
-		[
-			"MPI_Datatype",
-			"datatype"
-		],
-		[
-			"MPI_Message*",
-			"message"
-		],
-		[
-			"MPI_Status*",
-			"status"
-		]
-	],
-	"MPI_Imrecv": [
-		[
-			"void*",
-			"buf"
-		],
-		[
-			"int",
-			"count"
-		],
-		[
-			"MPI_Datatype",
-			"datatype"
-		],
-		[
-			"MPI_Message*",
-			"message"
-		],
-		[
-			"MPI_Request*",
-			"status"
-		]
-	]
+    "MPI_Wtick": [],
+    "MPI_Wtime": []
 }


### PR DESCRIPTION
This adds a fresh regeneration of the MPI symbols from the standard using @gweodoo 's fix on the mpi_meta tools.